### PR TITLE
Add `fob adopt <alias>` to convert existing ~/.ssh/config hosts to fob

### DIFF
--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -30,4 +30,49 @@ public enum HostSetup {
     public static func isValidHostToken(_ s: String) -> Bool {
         !s.isEmpty && !s.contains(" ") && !s.hasPrefix("-")
     }
+
+    /// What we read out of an existing `~/.ssh/config` Host block, for `fob adopt`.
+    public struct ParsedHost: Equatable {
+        public var hostName: String?
+        public var user: String?
+        public var port: Int?
+        public var identityFiles: [String]
+        public var usesFobAgent: Bool // IdentityAgent already points at ~/.fob/agent.sock
+    }
+
+    /// Reads the `Host <alias>` block from ssh-config text, if the alias appears as a
+    /// literal pattern (never via a wildcard/`Match` block — we won't touch those).
+    /// Returns nil when there's no such block.
+    public static func parseHostBlock(alias: String, in config: String) -> ParsedHost? {
+        var inBlock = false, found = false
+        var host = ParsedHost(hostName: nil, user: nil, port: nil, identityFiles: [], usesFobAgent: false)
+        for raw in config.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let lower = line.lowercased()
+            if lower == "host" || lower.hasPrefix("host ") || lower == "match" || lower.hasPrefix("match ") {
+                if inBlock { break } // reached the next section — our block ended
+                if lower.hasPrefix("host ") {
+                    let patterns = line.dropFirst(5).split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+                    if patterns.contains(alias) { inBlock = true; found = true }
+                }
+                continue
+            }
+            guard inBlock else { continue }
+            // key / value separated by whitespace or '='
+            guard let sep = line.firstIndex(where: { $0 == " " || $0 == "\t" || $0 == "=" }) else { continue }
+            let key = line[..<sep].lowercased()
+            let value = line[line.index(after: sep)...]
+                .trimmingCharacters(in: CharacterSet(charactersIn: " \t=\""))
+            switch key {
+            case "hostname": host.hostName = value
+            case "user": host.user = value
+            case "port": host.port = Int(value)
+            case "identityfile": host.identityFiles.append(value)
+            case "identityagent": if value.contains("/.fob/") { host.usesFobAgent = true }
+            default: break
+            }
+        }
+        return found ? host : nil
+    }
 }

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -4,6 +4,86 @@ import Foundation
 /// Guided end-to-end setup for one remote host: create (or reuse) an enclave key,
 /// export its public key, install it on the server, wire up ~/.ssh/config, verify.
 enum Setup {
+    /// `fob adopt <alias>` — convert an existing `~/.ssh/config` host to fob. Prints a
+    /// dry-run plan (generates the enclave key locally, but changes nothing on the
+    /// server or in ~/.ssh/config); the key install leans on your existing key auth,
+    /// so it's passwordless for hosts you can already reach.
+    static func adopt(store: KeyStore, arguments: [String]) throws {
+        var rest = arguments
+        let requireBiometry = rest.contains("--require-biometry")
+        rest.removeAll { $0 == "--require-biometry" }
+        guard rest.count == 1, let alias = rest.first, KeyStore.isValidName(alias) else {
+            throw AdoptError.usage
+        }
+
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+        let configText = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
+        guard let parsed = HostSetup.parseHostBlock(alias: alias, in: configText) else {
+            throw AdoptError.notConfigured(alias)
+        }
+        let host = parsed.hostName ?? alias
+        let user = parsed.user ?? NSUserName()
+        let port = parsed.port ?? 22
+
+        if parsed.usesFobAgent {
+            print("`\(alias)` already routes through fob (its IdentityAgent is ~/.fob/agent.sock).")
+            print("Nothing to adopt. Manage its key with: fob pin/reuse/policy \(alias)")
+            return
+        }
+
+        // Generate/reuse the enclave key and export the public key (safe, local-only).
+        let key: StoredKey
+        if let existing = try? store.find(name: alias) {
+            key = existing
+            print("Reusing existing fob key '\(alias)'.")
+        } else {
+            key = try store.create(name: alias, requireBiometry: requireBiometry)
+            print("Created Secure Enclave key '\(alias)' (\(requireBiometry ? "Touch ID only" : "Touch ID, Apple Watch, or password")).")
+        }
+        let pubURL = sshDir.appendingPathComponent("fob_\(alias).pub")
+        let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(alias)")
+        try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+
+        let portArg = port == 22 ? "" : " -p \(port)"
+        let old = parsed.identityFiles.first(where: { !$0.contains("/fob_") })
+        let isGitProvider = ["github.com", "gitlab.com", "bitbucket.org", "ssh.github.com"].contains(host.lowercased())
+
+        print("")
+        print("Adopting `\(alias)` (\(user)@\(host)\(port == 22 ? "" : ":\(port)")) into fob.")
+        print("Public key exported to \(pubURL.path).")
+        print("")
+        print("Dry run — nothing on the server or in ~/.ssh/config was changed. To convert,")
+        print("run these steps (they use your EXISTING key, so no password is needed):")
+        print("")
+        if isGitProvider {
+            print("1. Add the fob public key to your \(host) account (Settings → SSH keys):")
+            print("")
+            print("     \(pubLine)")
+        } else {
+            print("1. Install the fob key on the server (authenticates with your current key):")
+            print("")
+            print("     ssh-copy-id -f -i \(pubURL.path)\(portArg) \(alias)")
+        }
+        print("")
+        print("2. Point `Host \(alias)` in ~/.ssh/config at fob — ensure these lines are in")
+        print("   the block\(old.map { ", and comment out the old `IdentityFile \($0)`" } ?? ""):")
+        print("")
+        print("     IdentityAgent \(store.socketPath)")
+        print("     IdentityFile \(pubURL.path)")
+        print("     IdentitiesOnly yes")
+        print("")
+        print("3. Test (Touch ID will prompt):")
+        print("")
+        print("     ssh \(alias) true")
+        print("")
+        print("4. Pin the key so it only works for this host:")
+        print("")
+        print("     fob pin \(alias) \(host)")
+        print("")
+        print("5. Once it works, remove the old key from \(isGitProvider ? "your \(host) account" : "the server's ~/.ssh/authorized_keys").")
+    }
+
     static func run(store: KeyStore, arguments: [String]) throws {
         var rest = arguments
         let requireBiometry = rest.contains("--require-biometry")
@@ -292,6 +372,20 @@ enum SetupError: LocalizedError {
             return "could not install the public key on the server"
         case .verifyFailed(let destination):
             return "test connection to \(destination) failed — check the server's authorized_keys and sshd config"
+        }
+    }
+}
+
+enum AdoptError: LocalizedError {
+    case usage
+    case notConfigured(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .usage:
+            return "usage: fob adopt <alias> [--require-biometry]"
+        case .notConfigured(let alias):
+            return "no `Host \(alias)` entry in ~/.ssh/config — for a brand-new host use: fob setup \(alias)"
         }
     }
 }

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -20,6 +20,12 @@ USAGE:
       commands for you to inspect and run yourself — nothing is executed
       and ~/.ssh/config is not touched.
 
+  fob adopt <alias> [--require-biometry]
+      Convert an existing ~/.ssh/config host to fob. Prints a dry-run plan
+      (generates the enclave key locally but changes nothing on the server or
+      in ~/.ssh/config); the install step reuses your current key, so it's
+      passwordless for hosts you can already reach.
+
   fob list
       Print the public keys in authorized_keys format.
 
@@ -100,6 +106,9 @@ do {
 
     case "setup":
         try Setup.run(store: store, arguments: Array(arguments.dropFirst()))
+
+    case "adopt":
+        try Setup.adopt(store: store, arguments: Array(arguments.dropFirst()))
 
     case "list":
         let keys = try store.all()

--- a/Tests/FobKitTests/HostSetupTests.swift
+++ b/Tests/FobKitTests/HostSetupTests.swift
@@ -48,6 +48,43 @@ final class HostSetupTests: XCTestCase {
         XCTAssertEqual(blobs("192.168.1.9", 22).count, 1)
     }
 
+    func testParseHostBlock() {
+        let cfg = """
+        Host web
+          HostName example.com
+          User deploy
+          Port 2222
+          IdentityFile ~/.ssh/id_ed25519
+
+        Host other
+          HostName x.example
+        """
+        let p = HostSetup.parseHostBlock(alias: "web", in: cfg)
+        XCTAssertEqual(p?.hostName, "example.com")
+        XCTAssertEqual(p?.user, "deploy")
+        XCTAssertEqual(p?.port, 2222)
+        XCTAssertEqual(p?.identityFiles, ["~/.ssh/id_ed25519"])
+        XCTAssertEqual(p?.usesFobAgent, false)
+        XCTAssertNil(HostSetup.parseHostBlock(alias: "missing", in: cfg), "unknown alias → nil")
+        // Block ends at the next Host — don't leak `other`'s HostName into `web`.
+        XCTAssertNotEqual(p?.hostName, "x.example")
+    }
+
+    func testParseHostBlockIgnoresWildcardAndDetectsFob() {
+        let cfg = """
+        Host *
+          IdentityAgent ~/.fob/agent.sock
+        Host prod
+          HostName p.example
+          IdentityAgent ~/.fob/agent.sock
+        """
+        // 'foo' is only covered by the wildcard block → not an adoptable literal host.
+        XCTAssertNil(HostSetup.parseHostBlock(alias: "foo", in: cfg))
+        let p = HostSetup.parseHostBlock(alias: "prod", in: cfg)
+        XCTAssertEqual(p?.hostName, "p.example")
+        XCTAssertEqual(p?.usesFobAgent, true)
+    }
+
     func testValidHostToken() {
         XCTAssertTrue(HostSetup.isValidHostToken("example.com"))
         XCTAssertTrue(HostSetup.isValidHostToken("10.0.0.1"))


### PR DESCRIPTION
Reads the existing Host block (HostName/User/Port/IdentityFile), generates a fob key locally, and prints a dry-run plan to convert that host — changing nothing on the server or in ~/.ssh/config. The install step uses `ssh-copy-id` over your current key, so it's passwordless for hosts you can already reach; git providers (github.com, …) get an "add this key to your account" variant instead.

- FobKit HostSetup.parseHostBlock: conservative ssh-config block parser (literal alias only, never wildcard/Match blocks), detects an existing fob IdentityAgent.
- CLI `adopt` command + usage; refuses unknown hosts (points at `fob setup`).
- Tests for the parser (wildcard-ignoring, fob detection, block boundaries) — 28.