### PR TITLE
Add Touch ID-gated git commit signing (SSHSIG) with namespace restric…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The private key is generated **inside the Secure Enclave and never leaves it** �
 - 🎯 **Destination-aware prompts** — see *where* you're connecting, cryptographically verified
 - 📌 **Per-host pinning** — a key refuses every host but the one it's bound to
 - ⏱️ **Opt-in touch reuse** — one touch covers a `git` / `rsync` burst
+- ✍️ **Touch-ID commit signing** — sign git commits with a Secure Enclave key; GitHub/GitLab show *Verified*
 - 📜 **Tamper-evident audit log** — hash-chained record of every decision
 - 🖥️ **Menu-bar app + CLI** — live activity feed, guided setup, zero dependencies
 
@@ -108,6 +109,40 @@ A native notification on every event, so key use is never silent:
 | ⚠️ | something asked for a key this agent doesn't hold |
 
 Process attribution is best-effort (via the socket peer's PID) — treat it as awareness, not proof.
+
+### ✍️ Commit signing
+
+A fob key can also **sign git commits** — each `git commit` prompts Touch ID, and hosts
+that verify SSH signatures (**GitHub, GitLab, Gitea/Forgejo, Codeberg, …**) show the commit
+as **Verified**. It's standard SSH commit signing (`ssh-keygen -Y sign`), which fob's agent
+serves from the Secure Enclave — so it also verifies **locally**, host-independently, via an
+`allowed_signers` file. The same key can be **both** an *Authentication* key and a *Signing*
+key on your host (they're separate entries).
+
+```sh
+fob sign-setup <key>     # prints the exact steps below for a key you've generated
+```
+
+It walks you through three things:
+
+1. **Point the signer at fob.** `git`/`ssh-keygen` find the agent via `SSH_AUTH_SOCK`
+   (not ssh-config's `IdentityAgent`), so add to your shell profile:
+   `export SSH_AUTH_SOCK=~/.fob/agent.sock`
+2. **Configure git:** `gpg.format ssh`, `user.signingkey <the fob pubkey>`, `commit.gpgsign true`.
+3. **Register the public key on your git host as a *signing* key** — e.g. GitHub or
+   GitLab → Settings → SSH keys, added as a Signing Key (separate from an Authentication key).
+
+fob tells a signing request apart from an SSH login by the SSHSIG envelope's **namespace**
+(`git` for commits), shows a signing-specific prompt, and audits it as `signed-git`. You can
+restrict which namespaces a key may sign — the signing-side analog of pinning:
+
+```sh
+fob namespaces <key> git     # this key may only sign git commits
+fob namespaces <key> none    # disable signing entirely
+fob namespaces <key> any     # default — any namespace
+```
+
+A touch per commit adds up, so pair it with `fob reuse <key> <seconds>` for rebases/bursts.
 
 ## Security model
 

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -396,6 +396,7 @@ struct ContentView: View {
         case .denied:        return (e.key ?? "key", "\(act) · denied")
         case .refusedPin:    return (e.key ?? "key", "\(act) · blocked (wrong host)")
         case .refusedPolicy: return (e.key ?? "key", "\(act) · blocked (policy)")
+        case .refusedNamespace: return (e.key ?? "key", "\(act) · blocked (namespace)")
         case .unknownKey:    return (peerCmd(e.peer) ?? "unknown", (dest.map { " · \($0)" } ?? "") + " · unknown key")
         case .bind:          return (dest ?? "host", " · bound")
         case .bindRejected:  return (peerCmd(e.peer) ?? "client", " · bind rejected")
@@ -429,7 +430,7 @@ struct ContentView: View {
         switch kind {
         case .signed, .signedReused: return Theme.green
         case .denied: return .orange
-        case .refusedPin, .refusedPolicy, .bindRejected: return Theme.red
+        case .refusedPin, .refusedPolicy, .refusedNamespace, .bindRejected: return Theme.red
         case .unknownKey: return .yellow
         case .bind: return Theme.accent
         case .listening: return t.sub

--- a/Sources/FobKit/Agent.swift
+++ b/Sources/FobKit/Agent.swift
@@ -18,7 +18,7 @@ private enum AgentMessage: UInt8 {
 /// flows through here so the menu-bar app can show a live feed.
 public struct AgentEvent {
     public enum Kind: String {
-        case listening, signed, signedReused, denied, refusedPin, refusedPolicy, unknownKey, bind, bindRejected
+        case listening, signed, signedReused, denied, refusedPin, refusedPolicy, refusedNamespace, unknownKey, bind, bindRejected
     }
     public let kind: Kind
     public let message: String
@@ -270,6 +270,13 @@ public final class Agent: @unchecked Sendable {
             return Data([AgentMessage.failure.rawValue])
         }
 
+        // A commit/file signature (`ssh-keygen -Y sign`, e.g. git commit signing) rather
+        // than an SSH login: the payload is an SSHSIG envelope. It has no host binding,
+        // so it's gated by the key's allowed namespaces, not by host pinning.
+        if let namespace = SSHSIG.namespace(of: dataToSign) {
+            return signSSHSIG(key: key, data: dataToSign, namespace: namespace, policy: policy, peer: peer)
+        }
+
         // Pinning: a pinned key signs only for its verified, bound host — refused
         // before any Touch ID prompt, so a blocked request never costs a touch.
         if !policy.pinnedHostKeys.isEmpty {
@@ -324,6 +331,57 @@ public final class Agent: @unchecked Sendable {
             audit.record("denied", key: key.name, destination: destination, peer: peer)
             announce(.denied, "🚫 Signature request from \(peer) for \(destination) with key '\(key.name)' was denied",
                      key: key.name, destination: destination, peer: peer)
+            return Data([AgentMessage.failure.rawValue])
+        }
+    }
+
+    /// Sign an SSHSIG payload (git commit / `ssh-keygen -Y sign`). Gated by the key's
+    /// allowed namespaces rather than host pinning, with a signing-specific prompt and
+    /// a reuse window scoped to the namespace (so a signing grant can't be spent on SSH
+    /// auth, nor across namespaces).
+    private func signSSHSIG(key: StoredKey, data: Data, namespace: String,
+                            policy: KeyPolicy, peer: String) -> Data {
+        let purpose = namespace == "git" ? "a git commit" : "a \(namespace) signature"
+        guard policy.allowsSignature(namespace: namespace) else {
+            log("REFUSED signing \(purpose) with key '\(key.name)' (\(peer)) — namespace '\(namespace)' not allowed")
+            audit.record("refused-namespace", key: key.name, destination: namespace, peer: peer)
+            announce(.refusedNamespace, "⛔️ Blocked: \(peer) tried to sign \(purpose) with key '\(key.name)' — namespace ‘\(namespace)’ isn't allowed",
+                     key: key.name, destination: namespace, peer: peer)
+            return Data([AgentMessage.failure.rawValue])
+        }
+
+        let reuseWindow = min(policy.reuseSeconds ?? 0, 300)
+        let reuseScope = Data("sshsig:\(namespace)".utf8) // reuse is per-namespace, separate from SSH auth
+
+        if reuseWindow > 0, let cached = cachedAuthorization(for: key.name, destination: reuseScope) {
+            if let signature = try? key.privateKey(context: cached).signature(for: data) {
+                log("signed \(purpose) with key '\(key.name)' (\(peer)) — reuse window")
+                audit.record("signed-\(namespace)", key: key.name, destination: purpose, peer: peer)
+                announce(.signedReused, "🔑 \(peer) signed \(purpose) with key '\(key.name)' (reuse window)",
+                         key: key.name, destination: purpose, peer: peer)
+                return signResponse(signature)
+            }
+            dropAuthorization(for: key.name)
+        }
+
+        let context = LAContext()
+        context.localizedReason = "sign \(purpose)\nwith key “\(key.name)” · requested by \(peer)"
+        log("sign request from \(peer) to sign \(purpose) with key '\(key.name)' — waiting for user approval")
+        do {
+            let signature = try key.privateKey(context: context).signature(for: data)
+            log("signed \(purpose) with key '\(key.name)' (\(peer))")
+            audit.record("signed-\(namespace)", key: key.name, destination: purpose, peer: peer)
+            announce(.signed, "🔑 \(peer) signed \(purpose) with key '\(key.name)'",
+                     key: key.name, destination: purpose, peer: peer)
+            if reuseWindow > 0 {
+                storeAuthorization(context, for: key.name, seconds: reuseWindow, destination: reuseScope)
+            }
+            return signResponse(signature)
+        } catch {
+            log("signing \(purpose) with key '\(key.name)' (\(peer)) failed: \(error.localizedDescription)")
+            audit.record("denied", key: key.name, destination: purpose, peer: peer)
+            announce(.denied, "🚫 Request from \(peer) to sign \(purpose) with key '\(key.name)' was denied",
+                     key: key.name, destination: purpose, peer: peer)
             return Data([AgentMessage.failure.rawValue])
         }
     }

--- a/Sources/FobKit/KeyPolicy.swift
+++ b/Sources/FobKit/KeyPolicy.swift
@@ -13,11 +13,27 @@ public struct KeyPolicy: Codable {
     /// nil/0 = touch required for every signature. Applies to Touch ID only.
     public var reuseSeconds: Double?
 
-    public var isDefault: Bool { pinnedHostKeys.isEmpty && (reuseSeconds ?? 0) <= 0 }
+    /// SSHSIG namespaces this key may sign for (`ssh-keygen -Y sign` / git commit
+    /// signing). `nil` = any namespace allowed (the default, mirroring "no pin");
+    /// a list = only those namespaces (e.g. ["git"]); `[]` = signing disabled.
+    /// Does not affect SSH authentication, which is governed by `pinnedHostKeys`.
+    public var allowedNamespaces: [String]?
 
-    public init(pinnedHostKeys: [Data] = [], reuseSeconds: Double? = nil) {
+    public var isDefault: Bool {
+        pinnedHostKeys.isEmpty && (reuseSeconds ?? 0) <= 0 && allowedNamespaces == nil
+    }
+
+    /// Whether an SSHSIG signature for `namespace` is permitted by this policy.
+    public func allowsSignature(namespace: String) -> Bool {
+        guard let allowedNamespaces else { return true } // nil = any
+        return allowedNamespaces.contains(namespace)
+    }
+
+    public init(pinnedHostKeys: [Data] = [], reuseSeconds: Double? = nil,
+                allowedNamespaces: [String]? = nil) {
         self.pinnedHostKeys = pinnedHostKeys
         self.reuseSeconds = reuseSeconds
+        self.allowedNamespaces = allowedNamespaces
     }
 }
 

--- a/Sources/FobKit/SSHWire.swift
+++ b/Sources/FobKit/SSHWire.swift
@@ -104,3 +104,20 @@ public enum SSHFormat {
         return writer.data
     }
 }
+
+/// The SSHSIG signing envelope (`ssh-keygen -Y sign`, which is how git signs commits).
+/// The blob handed to the agent starts with the literal magic "SSHSIG" followed by a
+/// namespace string ("git" for commits) — letting the agent tell a *signature*
+/// operation apart from an SSH *authentication* and label / gate it accordingly.
+enum SSHSIG {
+    static let magic = Data("SSHSIG".utf8)
+
+    /// The namespace of an SSHSIG blob, or nil if `data` isn't one (e.g. it's an
+    /// ordinary SSH authentication payload, which never starts with this magic).
+    static func namespace(of data: Data) -> String? {
+        guard data.count > magic.count, data.prefix(magic.count) == magic else { return nil }
+        var reader = SSHReader(Data(data.dropFirst(magic.count)))
+        guard let namespace = try? reader.readString() else { return nil }
+        return String(decoding: namespace, as: UTF8.self)
+    }
+}

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -45,9 +45,10 @@ USAGE:
 
   fob sign-setup <name>
       Print how to use a key for Touch ID-gated git commit signing (SSH signing):
-      the SSH_AUTH_SOCK export, the git config, and the public key to add to
-      GitHub as a Signing Key. A key can be both an Authentication and a Signing
-      key. `git commit` then prompts Touch ID and GitHub shows "Verified".
+      the SSH_AUTH_SOCK export, the git config, and the public key to register on
+      your git host (GitHub, GitLab, Gitea/Forgejo, …) as a Signing Key. A key can
+      be both an Authentication and a Signing key. `git commit` then prompts Touch
+      ID and the host shows "Verified".
 
   fob namespaces <name> <any|none|ns1,ns2,...>
       Restrict which SSHSIG namespaces a key may sign (git commit signing uses
@@ -221,14 +222,15 @@ do {
         print("     git config --global commit.gpgsign true")
         print("     git config --global tag.gpgsign true")
         print("")
-        print("3. Add the key to GitHub → Settings → SSH and GPG keys → New SSH key,")
-        print("   with Key type: Signing Key (a separate entry from an Authentication Key):")
+        print("3. Register the key on your git host as a SIGNING key (a separate entry from")
+        print("   an Authentication key) — e.g. GitHub or GitLab → Settings → SSH keys:")
         print("     \(pubLine)")
         print("")
         print("4. (recommended) restrict this key to git signatures only:")
         print("     fob namespaces \(name) git")
         print("")
-        print("Then `git commit` prompts Touch ID via fob, and GitHub shows \"Verified\".")
+        print("Then `git commit` prompts Touch ID via fob, and your host (GitHub, GitLab,")
+        print("Gitea/Forgejo, …) shows \"Verified\". It also verifies locally via allowed_signers.")
 
     case "policy":
         let keys = try store.all()

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -43,8 +43,19 @@ USAGE:
       (max 300) — for git/rsync bursts. Every reused signature is still
       pin-checked, notified, and audited.
 
+  fob sign-setup <name>
+      Print how to use a key for Touch ID-gated git commit signing (SSH signing):
+      the SSH_AUTH_SOCK export, the git config, and the public key to add to
+      GitHub as a Signing Key. A key can be both an Authentication and a Signing
+      key. `git commit` then prompts Touch ID and GitHub shows "Verified".
+
+  fob namespaces <name> <any|none|ns1,ns2,...>
+      Restrict which SSHSIG namespaces a key may sign (git commit signing uses
+      "git"). any = any namespace (default); none = signing disabled; a list =
+      only those. Does not affect SSH authentication (see `pin`).
+
   fob policy
-      Show the pinning and reuse policy of every key.
+      Show the pinning, reuse, and signing policy of every key.
 
   fob audit [--verify]
       Show recent agent decisions (sign/deny/refuse/bind) from the
@@ -164,6 +175,61 @@ do {
             print("Key '\(key.name)': one approval now counts for \(Int(seconds))s of signatures.")
         }
 
+    case "namespaces":
+        let rest = Array(arguments.dropFirst())
+        guard rest.count == 2 else { fail("usage: fob namespaces <name> <any|none|ns1,ns2,...>") }
+        let key = try store.find(name: rest[0])
+        var policy = store.policy(name: key.name)
+        switch rest[1].lowercased() {
+        case "any": policy.allowedNamespaces = nil
+        case "none": policy.allowedNamespaces = []
+        default:
+            let list = rest[1].split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+            guard !list.isEmpty else { fail("usage: fob namespaces <name> <any|none|ns1,ns2,...>") }
+            policy.allowedNamespaces = list
+        }
+        try store.savePolicy(policy, name: key.name)
+        if let namespaces = policy.allowedNamespaces {
+            print(namespaces.isEmpty
+                ? "Key '\(key.name)' will refuse ALL signature requests."
+                : "Key '\(key.name)' will sign only for: \(namespaces.joined(separator: ", ")).")
+        } else {
+            print("Key '\(key.name)' may sign for any namespace.")
+        }
+
+    case "sign-setup":
+        guard let name = arguments.dropFirst().first, arguments.count == 2 else {
+            fail("usage: fob sign-setup <name>")
+        }
+        let key = try store.find(name: name)
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+        try FileManager.default.createDirectory(at: sshDir, withIntermediateDirectories: true,
+                                                attributes: [.posixPermissions: 0o700])
+        let pubURL = sshDir.appendingPathComponent("fob_\(name).pub")
+        let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
+        try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        print("Enable Touch ID-gated git commit signing with fob key '\(name)'.")
+        print("Public key exported to \(pubURL.path).")
+        print("")
+        print("1. Point ssh-keygen's signer at fob's agent (add to your shell profile):")
+        print("     export SSH_AUTH_SOCK=\(store.socketPath)")
+        print("")
+        print("2. Configure git to sign with this key:")
+        print("     git config --global gpg.format ssh")
+        print("     git config --global user.signingkey \(pubURL.path)")
+        print("     git config --global commit.gpgsign true")
+        print("     git config --global tag.gpgsign true")
+        print("")
+        print("3. Add the key to GitHub → Settings → SSH and GPG keys → New SSH key,")
+        print("   with Key type: Signing Key (a separate entry from an Authentication Key):")
+        print("     \(pubLine)")
+        print("")
+        print("4. (recommended) restrict this key to git signatures only:")
+        print("     fob namespaces \(name) git")
+        print("")
+        print("Then `git commit` prompts Touch ID via fob, and GitHub shows \"Verified\".")
+
     case "policy":
         let keys = try store.all()
         if keys.isEmpty { print("No keys yet.") }
@@ -181,6 +247,10 @@ do {
                 parts.append("touch reuse \(Int(reuse))s")
             } else {
                 parts.append("touch every time")
+            }
+            if let namespaces = policy.allowedNamespaces {
+                parts.append(namespaces.isEmpty ? "signing disabled"
+                                                : "signs only: \(namespaces.joined(separator: ", "))")
             }
             print("\(key.name): \(parts.joined(separator: "; "))")
         }

--- a/Tests/FobKitTests/SigningTests.swift
+++ b/Tests/FobKitTests/SigningTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+@testable import FobKit
+
+final class SigningTests: XCTestCase {
+    // MARK: SSHSIG detection
+
+    func testSSHSIGNamespaceParsed() {
+        var body = SSHWriter()
+        body.writeString("git") // the namespace, as an SSH string
+        let blob = SSHSIG.magic + body.data
+        XCTAssertEqual(SSHSIG.namespace(of: blob), "git")
+    }
+
+    func testNonSSHSIGReturnsNil() {
+        // An ordinary SSH auth payload (session id + fields) never starts with the magic.
+        var auth = SSHWriter()
+        auth.writeString("session-id-bytes")
+        XCTAssertNil(SSHSIG.namespace(of: auth.data))
+        XCTAssertNil(SSHSIG.namespace(of: Data([0x00, 0x01, 0x02])))
+        XCTAssertNil(SSHSIG.namespace(of: Data("SSHSIG".utf8))) // magic but no namespace
+    }
+
+    // MARK: Namespace policy
+
+    func testAllowsSignatureNamespaces() {
+        XCTAssertTrue(KeyPolicy().allowsSignature(namespace: "git"), "nil = any namespace")
+        XCTAssertTrue(KeyPolicy().allowsSignature(namespace: "file"))
+
+        let gitOnly = KeyPolicy(allowedNamespaces: ["git"])
+        XCTAssertTrue(gitOnly.allowsSignature(namespace: "git"))
+        XCTAssertFalse(gitOnly.allowsSignature(namespace: "file"))
+
+        let disabled = KeyPolicy(allowedNamespaces: [])
+        XCTAssertFalse(disabled.allowsSignature(namespace: "git"), "[] = signing disabled")
+    }
+
+    func testNamespaceRestrictionCountsAsNonDefault() {
+        XCTAssertTrue(KeyPolicy().isDefault)
+        XCTAssertFalse(KeyPolicy(allowedNamespaces: ["git"]).isDefault)
+        XCTAssertFalse(KeyPolicy(allowedNamespaces: []).isDefault)
+    }
+
+    func testPolicyRoundTripsNamespaces() throws {
+        let policy = KeyPolicy(pinnedHostKeys: [], reuseSeconds: 30, allowedNamespaces: ["git", "file"])
+        let data = try JSONEncoder().encode(policy)
+        let decoded = try JSONDecoder().decode(KeyPolicy.self, from: data)
+        XCTAssertEqual(decoded.allowedNamespaces, ["git", "file"])
+        XCTAssertEqual(decoded.reuseSeconds, 30)
+    }
+}


### PR DESCRIPTION
…tion

fob keys can now sign git commits (and other `ssh-keygen -Y sign` payloads) over the agent, so a fob key serves as both a GitHub Authentication key and a Signing key.

- Agent detects the SSHSIG envelope (magic + namespace) in a sign request and routes it through a signing path instead of SSH auth: no host binding, gated by the key's allowed namespaces (not pinning), a signing-specific Touch ID prompt ("sign a git commit …"), a reuse window scoped per-namespace, and `signed-git` audit entries.
- KeyPolicy.allowedNamespaces: nil = any (default), a list = only those (e.g. ["git"]), [] = signing disabled. New `.refusedNamespace` event.
- CLI: `fob sign-setup <name>` prints the SSH_AUTH_SOCK + git config + GitHub Signing-Key steps; `fob namespaces <name> <any|none|list>`; `fob policy` shows signing state.
- Tests for SSHSIG detection and namespace policy (33 total).