### PR TITLE
Add commit-signing setup UI (gpg.ssh.program wrapper, per-repo scope)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,15 @@ key on your host (they're separate entries).
 fob sign-setup <key>     # prints the exact steps below for a key you've generated
 ```
 
-It walks you through three things:
+It walks you through two things:
 
-1. **Point the signer at fob.** `git`/`ssh-keygen` find the agent via `SSH_AUTH_SOCK`
-   (not ssh-config's `IdentityAgent`), so add to your shell profile:
-   `export SSH_AUTH_SOCK=~/.fob/agent.sock`
-2. **Configure git:** `gpg.format ssh`, `user.signingkey <the fob pubkey>`, `commit.gpgsign true`.
-3. **Register the public key on your git host as a *signing* key** — e.g. GitHub or
+1. **Configure git** (`gpg.format ssh`, `user.signingkey <the fob pubkey>`,
+   `gpg.ssh.program <fob wrapper>`, `commit.gpgsign true`). fob points git's signer at
+   its agent through a tiny `gpg.ssh.program` wrapper (`~/.fob/bin/fob-sign`) rather than
+   `SSH_AUTH_SOCK` — so **only git signing** reaches fob, and any other ssh agent you run
+   (plus `git push` auth) is left untouched. Use `--global` for every repo, or `--local`
+   (run inside a repo) if you switch between multiple git identities.
+2. **Register the public key on your git host as a *signing* key** — e.g. GitHub or
    GitLab → Settings → SSH keys, added as a Signing Key (separate from an Authentication key).
 
 fob tells a signing request apart from an SSH login by the SSHSIG envelope's **namespace**

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -27,6 +27,8 @@ final class AppState: ObservableObject {
     @Published private(set) var fatalError: String?
     /// Transient error from the most recent key action, shown then cleared.
     @Published var actionError: String?
+    /// The key the "Commit signing" window is set up for (set before opening it).
+    @Published var signingSetupKey: String?
 
     private let store: KeyStore?
     private var agent: Agent?
@@ -221,6 +223,80 @@ final class AppState: ObservableObject {
         } catch {
             return error.localizedDescription
         }
+    }
+
+    // MARK: - Commit signing (the "Commit signing" window)
+
+    struct SigningInfo {
+        let name: String
+        let pubLine: String            // add to the git host as a Signing Key
+        let pubPath: String
+        let signerProgram: String      // ~/.fob/bin/fob-sign (git's gpg.ssh.program)
+        let gitOnly: Bool              // policy currently restricts signing to "git"
+
+        /// The git config commands for a scope ("--global" or "--local"). The view
+        /// builds these so it can switch scope without re-reading the key. Uses a
+        /// `gpg.ssh.program` wrapper so only git signing reaches fob — SSH_AUTH_SOCK
+        /// (and any other ssh agent the user runs) is left completely alone.
+        func gitConfigCommands(global: Bool) -> [String] {
+            let scope = global ? "--global" : "--local"
+            return [
+                "git config \(scope) gpg.format ssh",
+                "git config \(scope) user.signingkey \(pubPath)",
+                "git config \(scope) gpg.ssh.program \(signerProgram)",
+                "git config \(scope) commit.gpgsign true",
+                "git config \(scope) tag.gpgsign true",
+            ]
+        }
+    }
+
+    /// Exports the key's public key and gathers everything the signing window shows.
+    /// Returns nil if the key or store is unavailable.
+    func signingInfo(for name: String) -> SigningInfo? {
+        guard let store, let key = try? store.find(name: name) else { return nil }
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+        try? FileManager.default.createDirectory(at: sshDir, withIntermediateDirectories: true,
+                                                 attributes: [.posixPermissions: 0o700])
+        let pubURL = sshDir.appendingPathComponent("fob_\(name).pub")
+        guard let pubLine = try? SSHFormat.authorizedKeysLine(key.publicKey(), comment: "fob:\(name)") else {
+            return nil
+        }
+        try? Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        let signer = (try? store.ensureSignWrapper()) ?? store.signWrapperPath
+        return SigningInfo(
+            name: name, pubLine: pubLine, pubPath: pubURL.path,
+            signerProgram: signer,
+            gitOnly: store.policy(name: name).allowedNamespaces == ["git"])
+    }
+
+    /// Restrict a key to git-commit signatures only (["git"]), or clear the restriction.
+    func setGitSigningOnly(_ on: Bool, name: String) {
+        run { store in
+            var policy = store.policy(name: name)
+            policy.allowedNamespaces = on ? ["git"] : nil
+            try store.savePolicy(policy, name: name)
+        }
+    }
+
+    /// Run the `git config --global` signing setup for the user. nil = success.
+    func configureGitSigning(pubPath: String, signerProgram: String) -> String? {
+        for args in [["config", "--global", "gpg.format", "ssh"],
+                     ["config", "--global", "user.signingkey", pubPath],
+                     ["config", "--global", "gpg.ssh.program", signerProgram],
+                     ["config", "--global", "commit.gpgsign", "true"],
+                     ["config", "--global", "tag.gpgsign", "true"]] {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+            process.arguments = args
+            do {
+                try process.run(); process.waitUntilExit()
+                guard process.terminationStatus == 0 else { return "`git \(args.joined(separator: " "))` failed" }
+            } catch {
+                return error.localizedDescription
+            }
+        }
+        return nil
     }
 
     func unpin(name: String) {

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -337,6 +337,11 @@ struct ContentView: View {
                 menuItem("Unpin (any destination)", color: t.text) { state.unpin(name: key.name) }
             }
             menuItem("Pin to host…", color: t.text) { state.requestPin(name: key.name) }
+            menuItem("Use for commit signing…", color: t.text) {
+                state.signingSetupKey = key.name
+                NSApp.activate(ignoringOtherApps: true)
+                openWindow(id: SigningSetupView.windowID)
+            }
             menuItem("Delete…", color: Theme.red) { state.requestDelete(name: key.name) }
         }
         .padding(6)

--- a/Sources/FobApp/FobApp.swift
+++ b/Sources/FobApp/FobApp.swift
@@ -17,6 +17,11 @@ struct FobApp: App {
             HostSetupView().environmentObject(state)
         }
         .windowResizability(.contentSize)
+
+        Window("Commit signing", id: SigningSetupView.windowID) {
+            SigningSetupView().environmentObject(state)
+        }
+        .windowResizability(.contentSize)
     }
 }
 

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -1,0 +1,123 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The "Commit signing" window (opened from a key's ••• menu). Sets a fob key up for
+/// Touch ID-gated git commit signing: shows the public key to register on your git
+/// host and the git config (per-repo or global, with a one-click apply for global).
+/// Signing is routed to fob via a `gpg.ssh.program` wrapper, so it never touches
+/// SSH_AUTH_SOCK — other ssh agents and `git push` auth are unaffected. The one thing
+/// it does directly is the namespace restriction — fob's own policy.
+struct SigningSetupView: View {
+    static let windowID = "fob-signing-setup"
+
+    @EnvironmentObject var state: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    private enum Scope { case repository, global }
+
+    @State private var info: AppState.SigningInfo?
+    @State private var gitOnly = false
+    @State private var scope: Scope = .repository
+    @State private var copied: String?
+    @State private var gitConfigured = false
+    @State private var gitError: String?
+
+    private var keyName: String { state.signingSetupKey ?? "" }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Commit signing — \(keyName)").font(.title2.weight(.semibold))
+            }
+            if let info { content(info) } else { Text("Key unavailable.").foregroundStyle(.secondary) }
+        }
+        .padding(22)
+        .frame(width: 500)
+        .onAppear { load() }
+        .onChange(of: state.signingSetupKey) { _ in load() }
+    }
+
+    private func load() {
+        info = state.signingInfo(for: keyName)
+        gitOnly = info?.gitOnly ?? false
+        gitConfigured = false; gitError = nil; copied = nil
+    }
+
+    @ViewBuilder
+    private func content(_ info: AppState.SigningInfo) -> some View {
+        Text("Sign git commits with “\(keyName)” — Touch ID on each commit, and your host (GitHub, GitLab, …) shows *Verified*.")
+            .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+
+        Toggle(isOn: Binding(get: { gitOnly }, set: { gitOnly = $0; state.setGitSigningOnly($0, name: keyName) })) {
+            Text("Restrict this key to git commits only").font(.callout)
+        }
+        .toggleStyle(.checkbox)
+
+        step(1, "Register the public key on your git host as a Signing Key",
+             "e.g. GitHub / GitLab → Settings → SSH keys (a separate entry from an Authentication key):")
+        copyBox(info.pubLine, id: "pub")
+
+        step(2, "Configure git to sign with this key", nil)
+        Picker("Scope", selection: $scope) {
+            Text("This repo").tag(Scope.repository)
+            Text("All repos (global)").tag(Scope.global)
+        }
+        .pickerStyle(.segmented).labelsHidden().frame(width: 260)
+        Text(scope == .repository
+             ? "Recommended if you switch between git identities — run these **inside** the repo you want to sign. Doesn't touch your other repos."
+             : "⚠️ Sets signing for **every** repo on this Mac. If you use multiple git accounts, use “This repo” instead.")
+            .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        copyBox(info.gitConfigCommands(global: scope == .global).joined(separator: "\n"), id: "git")
+        if scope == .global {
+            HStack(spacing: 10) {
+                Button(gitConfigured ? "Configured ✓" : "Configure git for me") {
+                    if let err = state.configureGitSigning(pubPath: info.pubPath, signerProgram: info.signerProgram) { gitError = err; gitConfigured = false }
+                    else { gitConfigured = true; gitError = nil }
+                }
+                .disabled(gitConfigured)
+                if let gitError {
+                    Text(gitError).font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
+                } else if gitConfigured {
+                    Text("git config --global set").font(.caption).foregroundStyle(.green)
+                }
+            }
+        } else {
+            Text("Copy and run these in the repo (the app can't target a repo for you).")
+                .font(.caption).foregroundStyle(.tertiary)
+        }
+
+        Text("fob signs commits through a `gpg.ssh.program` wrapper, so it **won't** change `SSH_AUTH_SOCK` — your other ssh agents and `git push` auth are untouched.")
+            .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        Text("Tip: a touch per commit adds up — pair with a reuse window (the key's ••• → Touch reuse) for rebases.")
+            .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+
+        HStack {
+            Spacer()
+            Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+        }
+    }
+
+    private func step(_ n: Int, _ title: String, _ detail: String?) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(n). \(title)").font(.callout.weight(.semibold))
+            if let detail {
+                Text(detail).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func copyBox(_ text: String, id: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(text).font(.system(.caption, design: .monospaced)).textSelection(.enabled)
+                .padding(8).frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.12)))
+            Button(copied == id ? "Copied" : "Copy") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+                copied = id
+            }
+        }
+    }
+}

--- a/Sources/FobKit/KeyStore.swift
+++ b/Sources/FobKit/KeyStore.swift
@@ -92,6 +92,37 @@ public struct KeyStore {
     public var keysDirectory: URL { directory.appendingPathComponent("keys") }
     public var socketPath: String { directory.appendingPathComponent("agent.sock").path }
 
+    /// Path to the git-signing wrapper (`~/.fob/bin/fob-sign`). Set as git's
+    /// `gpg.ssh.program` so *only* commit signing reaches fob's agent — SSH_AUTH_SOCK
+    /// stays untouched, so other ssh agents and `git push` auth are unaffected.
+    public var signWrapperPath: String {
+        directory.appendingPathComponent("bin/fob-sign").path
+    }
+
+    /// Create (or refresh) the git-signing wrapper and return its path. The wrapper
+    /// sets SSH_AUTH_SOCK to fob's socket only for the `ssh-keygen -Y sign` invocation
+    /// that git runs, leaving the user's global agent selection alone.
+    @discardableResult
+    public func ensureSignWrapper() throws -> String {
+        let bin = directory.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(
+            at: bin, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let wrapper = bin.appendingPathComponent("fob-sign")
+        let script = """
+        #!/bin/sh
+        # fob: route only git's SSH signing to fob's agent, without touching SSH_AUTH_SOCK
+        # (so your other ssh agents and `git push` auth are unaffected). Set as git's
+        # gpg.ssh.program. Managed by fob — regenerated on setup.
+        exec env SSH_AUTH_SOCK="\(socketPath)" /usr/bin/ssh-keygen "$@"
+
+        """
+        try script.data(using: .utf8)!.write(to: wrapper)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: wrapper.path)
+        return wrapper.path
+    }
+
     /// Valid key/alias name: letters, digits, '.', '_', '-', and never a leading '-'.
     /// These names become CLI arguments (`ssh <alias>`, `-i <file>`) and filenames, so
     /// they must never be parseable as an option nor contain path/shell metacharacters.

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -45,10 +45,10 @@ USAGE:
 
   fob sign-setup <name>
       Print how to use a key for Touch ID-gated git commit signing (SSH signing):
-      the SSH_AUTH_SOCK export, the git config, and the public key to register on
-      your git host (GitHub, GitLab, Gitea/Forgejo, …) as a Signing Key. A key can
-      be both an Authentication and a Signing key. `git commit` then prompts Touch
-      ID and the host shows "Verified".
+      the git config (routed to fob via a gpg.ssh.program wrapper, so SSH_AUTH_SOCK
+      is untouched) and the public key to register on your git host (GitHub, GitLab,
+      Gitea/Forgejo, …) as a Signing Key. A key can be both an Authentication and a
+      Signing key. `git commit` then prompts Touch ID and the host shows "Verified".
 
   fob namespaces <name> <any|none|ns1,ns2,...>
       Restrict which SSHSIG namespaces a key may sign (git commit signing uses
@@ -210,23 +210,26 @@ do {
         let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
         try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        let signer = try store.ensureSignWrapper()
         print("Enable Touch ID-gated git commit signing with fob key '\(name)'.")
         print("Public key exported to \(pubURL.path).")
         print("")
-        print("1. Point ssh-keygen's signer at fob's agent (add to your shell profile):")
-        print("     export SSH_AUTH_SOCK=\(store.socketPath)")
-        print("")
-        print("2. Configure git to sign with this key:")
+        print("1. Configure git to sign with this key. Use --global for every repo, or")
+        print("   --local (run inside a repo) if you juggle multiple git identities:")
         print("     git config --global gpg.format ssh")
         print("     git config --global user.signingkey \(pubURL.path)")
+        print("     git config --global gpg.ssh.program \(signer)")
         print("     git config --global commit.gpgsign true")
         print("     git config --global tag.gpgsign true")
         print("")
-        print("3. Register the key on your git host as a SIGNING key (a separate entry from")
+        print("   The gpg.ssh.program wrapper routes ONLY git signing to fob's agent, so")
+        print("   SSH_AUTH_SOCK is untouched — other ssh agents and `git push` still work.")
+        print("")
+        print("2. Register the key on your git host as a SIGNING key (a separate entry from")
         print("   an Authentication key) — e.g. GitHub or GitLab → Settings → SSH keys:")
         print("     \(pubLine)")
         print("")
-        print("4. (recommended) restrict this key to git signatures only:")
+        print("3. (recommended) restrict this key to git signatures only:")
         print("     fob namespaces \(name) git")
         print("")
         print("Then `git commit` prompts Touch ID via fob, and your host (GitHub, GitLab,")


### PR DESCRIPTION
Open "Use for commit signing…" from a key's ••• menu to set a fob key up for Touch ID-gated git commit signing, without a terminal.

Routing: point git's signer at fob through a small gpg.ssh.program wrapper (~/.fob/bin/fob-sign) instead of overriding SSH_AUTH_SOCK. Only git signing reaches fob — other ssh agents and `git push` auth are left untouched. This fixes the earlier guidance that told users to export SSH_AUTH_SOCK globally, which would have redirected all ssh auth to fob.

The dialog offers a scope choice: "This repo" (git config --local, safe when juggling multiple git identities) or "All repos" (--global, with a one-click "Configure git for me"). It also exposes the namespace restriction toggle and the public key to register as a Signing Key.

- FobKit: KeyStore.ensureSignWrapper()/signWrapperPath write + locate the wrapper
- FobApp: SigningSetupView window + AppState signing helpers + ••• menu item
- CLI: `fob sign-setup` uses the wrapper approach; usage text updated
- README: commit-signing section rewritten around the wrapper

Verified end-to-end: git commit with SSH_AUTH_SOCK unset → Touch ID → Good "git" signature.