### PR TITLE
Add guided server migration (adopt existing SSH hosts to fob)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The private key is generated **inside the Secure Enclave and never leaves it** �
 - 📌 **Per-host pinning** — a key refuses every host but the one it's bound to
 - ⏱️ **Opt-in touch reuse** — one touch covers a `git` / `rsync` burst
 - ✍️ **Touch-ID commit signing** — sign git commits with a Secure Enclave key; GitHub/GitLab show *Verified*
+- 🚚 **Safe migration** — moves an existing SSH host to fob *alongside* the old key; no cutover, no lockout
 - 📜 **Tamper-evident audit log** — hash-chained record of every decision
 - 🖥️ **Menu-bar app + CLI** — live activity feed, guided setup, zero dependencies
 
@@ -68,6 +69,27 @@ fob test-sign mykey                   # 5. verify the Touch ID flow, no server n
 ```
 
 </details>
+
+## Already using SSH keys? Migrate
+
+fob **can't import** an existing key — the Secure Enclave only generates keys on-device (P-256). That's the safety feature, not a limitation: migration means fob adds a **new key alongside your old one**, proves it works, and lets you retire the old one *when you choose*. Your current key keeps working the whole time — **no cutover, no lockout**.
+
+For a host already in your `~/.ssh/config`, one command does it — it installs the fob key using your **current** key (so it's passwordless for hosts you can already reach), backs up and rewrites the config block (showing a diff first), verifies over Touch ID, and pins:
+
+```sh
+fob adopt myserver               # preview only: fob adopt myserver --dry-run
+```
+
+The old `IdentityFile` stays active as a fallback. Once you've confirmed fob works:
+
+```sh
+fob adopt myserver --retire      # comment the old key out of ~/.ssh/config
+# then remove the old public key from the server's ~/.ssh/authorized_keys
+```
+
+**From the menu-bar app:** open the panel → **Migrate a server…**. It lists the hosts in your `~/.ssh/config` and walks each one through install → config diff → **Verify (Touch ID)** → pin → optional retire, with a timestamped `~/.ssh/config` backup at every write.
+
+> Git hosts (GitHub/GitLab) don't take an `ssh-copy-id` install — `adopt` prints the public key to add under **Settings → SSH keys** instead, then wires up the config. To move commit *signing* to fob, use a key's ••• → **Use for commit signing…** (see below).
 
 ## How it works
 
@@ -179,8 +201,10 @@ A full third-party-style audit of this codebase (findings resolved) plus a regre
 | Command | Description |
 |---|---|
 | `fob setup [alias] [user@host]` | Guided end-to-end host onboarding |
+| `fob adopt <alias> [--dry-run] [--retire]` | Migrate an existing `~/.ssh/config` host to fob |
 | `fob generate <name> [--require-biometry]` | Create a Secure Enclave key |
 | `fob list` | Print public keys (authorized_keys format) |
+| `fob delete <key> [--force]` | Permanently erase a key from the enclave |
 | `fob pin <key> <host>` · `fob unpin <key>` | Restrict a key to a host / remove all pins |
 | `fob reuse <key> <seconds\|off>` | Set the touch-reuse window (max 300 s) |
 | `fob policy` | Show every key's pin + reuse state |

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -29,6 +29,8 @@ final class AppState: ObservableObject {
     @Published var actionError: String?
     /// The key the "Commit signing" window is set up for (set before opening it).
     @Published var signingSetupKey: String?
+    /// The alias the "Migrate a server" window is set up for (set before opening it).
+    @Published var migrateAlias: String?
 
     private let store: KeyStore?
     private var agent: Agent?
@@ -100,8 +102,23 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// The most recently generated key's public line, so the panel can show a copyable
+    /// key + "what next" instead of leaving a freshly generated key as a dead end.
+    struct GeneratedKey: Equatable { let name: String; let pubLine: String }
+    @Published var lastGenerated: GeneratedKey?
+
     func generate(name: String, requireBiometry: Bool) {
-        run { store in _ = try store.create(name: name, requireBiometry: requireBiometry) }
+        guard let store else { actionError = "store unavailable"; return }
+        do {
+            let key = try store.create(name: name, requireBiometry: requireBiometry)
+            lastGenerated = GeneratedKey(
+                name: name,
+                pubLine: SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)"))
+            actionError = nil
+        } catch {
+            actionError = error.localizedDescription
+        }
+        refreshKeys()
     }
 
     func delete(name: String) {
@@ -222,6 +239,199 @@ final class AppState: ObservableObject {
             return nil
         } catch {
             return error.localizedDescription
+        }
+    }
+
+    // MARK: - Server migration (the "Migrate" windows)
+
+    /// An existing `~/.ssh/config` server, as a migration candidate.
+    struct MigrationCandidate: Identifiable {
+        let alias: String
+        let host: String
+        let user: String
+        let port: Int
+        let usesFob: Bool
+        let oldIdentityFiles: [String]
+        var id: String { alias }
+        var destination: String { port == 22 ? "\(user)@\(host)" : "\(user)@\(host):\(port)" }
+    }
+
+    enum InstallOutcome {
+        case installed        // fob key appended to the server's authorized_keys
+        case alreadyPresent   // it was already there
+        // headless install couldn't run — do it in a terminal. `detail` is the sanitized
+        // ssh output (why it failed), empty if there was none.
+        case needsManual(command: String, detail: String)
+        case failed(String)   // a real error (bad alias / key store)
+    }
+
+    /// Result of a ~/.ssh/config write: the backup filename on success, else a message.
+    enum ConfigWriteResult {
+        case ok(backup: String)
+        case error(String)
+    }
+
+    private var sshConfigURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/config")
+    }
+    private func fobPubURL(_ alias: String) -> URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/fob_\(alias).pub")
+    }
+
+    /// Every literal `Host` block in ~/.ssh/config, as migration candidates.
+    func discoverServers() -> [MigrationCandidate] {
+        let text = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        return HostSetup.listHostBlocks(in: text).map { block in
+            MigrationCandidate(
+                alias: block.alias,
+                host: block.parsed.hostName ?? block.alias,
+                user: block.parsed.user ?? NSUserName(),
+                port: block.parsed.port ?? 22,
+                usesFob: block.usesFob,
+                oldIdentityFiles: block.parsed.identityFiles.filter { !$0.contains("/fob_") })
+        }
+    }
+
+    /// The candidate for a single alias (re-read fresh from config).
+    func migrationCandidate(alias: String) -> MigrationCandidate? {
+        discoverServers().first { $0.alias == alias }
+    }
+
+    /// Whether git commit signing is already configured (informational in the migrate view).
+    func gitSigningInfo() -> GitConfig.SigningInfo {
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".gitconfig")
+        return GitConfig.parse((try? String(contentsOf: url, encoding: .utf8)) ?? "")
+    }
+
+    /// Create (or reuse) the fob key, export its public key, and install it on the server
+    /// using the host's CURRENT key (headless, passwordless). Runs BEFORE the config is
+    /// rewritten, so `ssh <alias>` still authenticates with the old key. `.failure` is a
+    /// real error (bad alias / key store); an unreachable/passphrase-locked host resolves
+    /// to `.success(.needsManual)` with a copy-paste fallback.
+    func createAndInstall(_ c: MigrationCandidate, requireBiometry: Bool) async -> InstallOutcome {
+        guard let store else { return .failed("Key store unavailable.") }
+        guard KeyStore.isValidName(c.alias) else { return .failed("Invalid alias “\(c.alias)”.") }
+        let pubLine: String
+        do {
+            let key: StoredKey
+            if let existing = try? store.find(name: c.alias) { key = existing }
+            else { key = try store.create(name: c.alias, requireBiometry: requireBiometry) }
+            pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(c.alias)")
+            let pubURL = fobPubURL(c.alias)
+            try FileManager.default.createDirectory(at: pubURL.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true,
+                                                    attributes: [.posixPermissions: 0o700])
+            try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            refreshKeys()
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+        let fallback = HostSetup.fallbackCopyCommand(alias: c.alias, fobPubPath: fobPubURL(c.alias).path, port: c.port)
+        guard let args = HostSetup.installArguments(alias: c.alias) else {
+            return .needsManual(command: fallback, detail: "")
+        }
+        let (status, output) = await runProcess("/usr/bin/ssh", args, stdin: pubLine + "\n")
+        if status == 0 && output.contains("fob-installed") { return .installed }
+        if status == 0 && output.contains("fob-present") { return .alreadyPresent }
+        return .needsManual(command: fallback, detail: HostSetup.sanitizeForDisplay(output))
+    }
+
+    /// The `old → new` ~/.ssh/config text for the diff preview, or nil if there's no
+    /// literal block (or it's already fully migrated).
+    func configDiff(alias: String) -> (old: String, new: String)? {
+        guard let store else { return nil }
+        let old = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        guard let new = HostSetup.migratedConfig(old, alias: alias,
+                                                 fobPubPath: fobPubURL(alias).path,
+                                                 socketPath: store.socketPath),
+              new != old else { return nil }
+        return (old, new)
+    }
+
+    /// Back up ~/.ssh/config and write the migrated version. Returns the backup filename
+    /// on success (for undo guidance), or an error message.
+    func applyConfigMigration(alias: String) -> ConfigWriteResult {
+        guard let store else { return .error("Key store unavailable.") }
+        let old = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        guard let new = HostSetup.migratedConfig(old, alias: alias,
+                                                 fobPubPath: fobPubURL(alias).path,
+                                                 socketPath: store.socketPath) else {
+            return .error("No “Host \(alias)” block found in ~/.ssh/config.")
+        }
+        do {
+            let backup = try HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
+            return .ok(backup: backup.lastPathComponent)
+        } catch {
+            return .error(error.localizedDescription)
+        }
+    }
+
+    /// Prove fob works for this host by connecting with ONLY the fob identity (not the
+    /// old-key fallback), so a green check means fob specifically succeeded. Touch ID
+    /// prompts. Returns nil on success, else an error message.
+    func verifyMigration(_ c: MigrationCandidate) async -> String? {
+        guard let store else { return "Key store unavailable." }
+        var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", "IdentitiesOnly=yes",
+                    "-o", "IdentityAgent=\(store.socketPath)",
+                    "-i", fobPubURL(c.alias).path]
+        if c.port != 22 { args += ["-p", String(c.port)] }
+        args += ["\(c.user)@\(c.host)", "true"]
+        let (status, output) = await runProcess("/usr/bin/ssh", args)
+        guard status == 0 else {
+            let tail = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return "Test connection failed — your existing key still works, nothing was removed."
+                + (tail.isEmpty ? "" : "\n\(tail)")
+        }
+        return nil
+    }
+
+    /// Comment out the old `IdentityFile` in the block (the explicit, optional retire step),
+    /// after the user has confirmed fob works. Returns the backup filename or an error.
+    func retireOldKey(alias: String) -> ConfigWriteResult {
+        guard let store else { return .error("Key store unavailable.") }
+        let old = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        guard let new = HostSetup.migratedConfig(old, alias: alias,
+                                                 fobPubPath: fobPubURL(alias).path,
+                                                 socketPath: store.socketPath, retireOld: true) else {
+            return .error("No “Host \(alias)” block found in ~/.ssh/config.")
+        }
+        do {
+            let backup = try HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
+            return .ok(backup: backup.lastPathComponent)
+        } catch {
+            return .error(error.localizedDescription)
+        }
+    }
+
+    /// Run a subprocess off the main actor, feeding `stdin` if given, capturing merged
+    /// stdout+stderr. `/usr/bin/ssh` bounds itself via BatchMode + ConnectTimeout.
+    private func runProcess(_ launchPath: String, _ args: [String], stdin: String? = nil) async -> (status: Int32, output: String) {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: launchPath)
+                process.arguments = args
+                let outPipe = Pipe()
+                process.standardOutput = outPipe
+                process.standardError = outPipe
+                var inPipe: Pipe?
+                if stdin != nil { let p = Pipe(); process.standardInput = p; inPipe = p }
+                do {
+                    try process.run()
+                    if let stdin, let inPipe {
+                        inPipe.fileHandleForWriting.write(Data(stdin.utf8))
+                        try? inPipe.fileHandleForWriting.close()
+                    }
+                    let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                    process.waitUntilExit()
+                    continuation.resume(returning: (process.terminationStatus, String(decoding: data, as: UTF8.self)))
+                } catch {
+                    continuation.resume(returning: (-1, error.localizedDescription))
+                }
+            }
         }
     }
 

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -133,16 +133,34 @@ struct ContentView: View {
     private var keysSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionLabel("KEYS").padding(.horizontal, 14).padding(.top, 12).padding(.bottom, 4)
-            if state.keys.isEmpty {
-                Text("No keys yet — create one below.")
-                    .font(.system(size: 11)).foregroundStyle(t.sub)
-                    .padding(.horizontal, 14).padding(.bottom, 8)
-            }
+            if state.keys.isEmpty { emptyState }
             ForEach(state.keys) { key in
                 keyRow(key)
                 Rectangle().fill(t.div2).frame(height: 0.5).padding(.horizontal, 14)
             }
         }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Welcome to fob")
+                .font(.system(size: 13, weight: .semibold)).foregroundStyle(t.text)
+            Text("fob keeps SSH keys in the Secure Enclave, unlocked by Touch ID. Already using SSH keys? Migrate a server — fob adds a new key alongside the old one and proves it works before you retire anything.")
+                .font(.system(size: 11.5)).foregroundStyle(t.sub).fixedSize(horizontal: false, vertical: true)
+            Button {
+                NSApp.activate(ignoringOtherApps: true)
+                openWindow(id: MigrateView.windowID)
+            } label: {
+                Text("Migrate an existing server…")
+                    .font(.system(size: 12.5, weight: .semibold)).foregroundStyle(.white)
+                    .padding(.horizontal, 14).frame(height: 28)
+                    .background(RoundedRectangle(cornerRadius: 7).fill(Theme.accent))
+            }
+            .buttonStyle(.plain)
+            Text("…or create your first key below.")
+                .font(.system(size: 11)).foregroundStyle(t.sub)
+        }
+        .padding(.horizontal, 14).padding(.top, 2).padding(.bottom, 10)
     }
 
     private func keyRow(_ key: KeyInfo) -> some View {
@@ -212,19 +230,54 @@ struct ContentView: View {
             .buttonStyle(.plain)
             .padding(.horizontal, 14).padding(.top, 10).padding(.bottom, 8)
 
-            Button {
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: HostSetupView.windowID)
-            } label: {
-                HStack(spacing: 5) {
-                    Image(systemName: "sparkles")
-                    Text("Set up a remote host…")
+            if let gen = state.lastGenerated { generatedBox(gen) }
+
+            HStack(spacing: 16) {
+                linkButton("sparkles", "Set up a remote host…") {
+                    openWindow(id: HostSetupView.windowID)
                 }
-                .font(.system(size: 12)).foregroundStyle(Theme.accent)
+                linkButton("arrow.right.arrow.left", "Migrate a server…") {
+                    openWindow(id: MigrateView.windowID)
+                }
             }
-            .buttonStyle(.plain)
             .padding(.horizontal, 14).padding(.bottom, 12)
         }
+    }
+
+    private func linkButton(_ icon: String, _ title: String, _ action: @escaping () -> Void) -> some View {
+        Button {
+            NSApp.activate(ignoringOtherApps: true)
+            action()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: icon)
+                Text(title)
+            }
+            .font(.system(size: 12)).foregroundStyle(Theme.accent)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func generatedBox(_ gen: AppState.GeneratedKey) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("“\(gen.name)” created. Add this public key where you'll use it — a server's authorized_keys, or GitHub/GitLab:")
+                .font(.system(size: 11)).foregroundStyle(t.sub).fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 8) {
+                Text(gen.pubLine)
+                    .font(.system(size: 10, design: .monospaced)).foregroundStyle(t.text)
+                    .lineLimit(2).truncationMode(.middle)
+                    .padding(8).frame(maxWidth: .infinity, alignment: .leading)
+                    .background(RoundedRectangle(cornerRadius: 6).fill(t.fieldBg))
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(gen.pubLine, forType: .string)
+                } label: {
+                    Text("Copy").font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.accent)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 14).padding(.bottom, 8)
     }
 
     private func generate() {

--- a/Sources/FobApp/FobApp.swift
+++ b/Sources/FobApp/FobApp.swift
@@ -22,6 +22,16 @@ struct FobApp: App {
             SigningSetupView().environmentObject(state)
         }
         .windowResizability(.contentSize)
+
+        Window("Migrate to fob", id: MigrateView.windowID) {
+            MigrateView().environmentObject(state)
+        }
+        .windowResizability(.contentSize)
+
+        Window("Migrate a server", id: MigrateHostView.windowID) {
+            MigrateHostView().environmentObject(state)
+        }
+        .windowResizability(.contentSize)
     }
 }
 

--- a/Sources/FobApp/MigrateHostView.swift
+++ b/Sources/FobApp/MigrateHostView.swift
@@ -1,0 +1,327 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The per-host migration flow (opened from MigrateView). Staged, and safe by design:
+/// install the fob key on the server (using your existing key) → preview + back up +
+/// apply the ~/.ssh/config edit → verify fob works with Touch ID → pin, and only then
+/// optionally retire the old key. The old key stays active until Retire, so there's no
+/// lockout at any step.
+struct MigrateHostView: View {
+    static let windowID = "fob-migrate-host"
+
+    @EnvironmentObject var state: AppState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var candidate: AppState.MigrationCandidate?
+    @State private var alreadyMigrated = false
+    @State private var biometry = true
+    @State private var busy = false
+
+    // Progressive stage results.
+    @State private var install: InstallUI?
+    @State private var applied: Status?
+    @State private var verified: Status?
+    @State private var pinned = false
+    @State private var pinNote: String?
+    @State private var retired: Status?
+
+    private enum InstallUI {
+        case done(String)              // green summary
+        case manual(command: String, detail: String) // fallback command + why headless failed
+        case error(String)
+    }
+    private struct Status { let ok: Bool; let text: String }
+
+    private var alias: String { state.migrateAlias ?? "" }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Migrate “\(alias)” to fob").font(.title2.weight(.semibold))
+            }
+            if let candidate { content(candidate) }
+            else { Text("This host is no longer in ~/.ssh/config.").foregroundStyle(.secondary) }
+        }
+        .padding(22)
+        .frame(width: 520)
+        .onAppear(perform: load)
+        .onChange(of: state.migrateAlias) { _ in load() }
+    }
+
+    private func load() {
+        candidate = state.migrationCandidate(alias: alias)
+        alreadyMigrated = candidate?.usesFob ?? false
+        install = nil; applied = nil; verified = nil
+        pinned = state.keys.first { $0.name == alias }?.isPinned ?? false
+        pinNote = nil; retired = nil; busy = false
+    }
+
+    @ViewBuilder
+    private func content(_ c: AppState.MigrationCandidate) -> some View {
+        if alreadyMigrated {
+            migratedContent(c)
+        } else {
+            freshContent(c)
+        }
+        HStack {
+            Spacer()
+            Button("Done") { dismiss() }.keyboardShortcut(.defaultAction)
+        }
+    }
+
+    /// Re-entry view for a host already routed through fob — jump straight to verify
+    /// (optional reassurance) and retire, which is easy to miss on the first pass.
+    @ViewBuilder
+    private func migratedContent(_ c: AppState.MigrationCandidate) -> some View {
+        Label("“\(alias)” already routes through fob. Your old key stays a working fallback until you retire it — do that whenever you're ready.",
+              systemImage: "checkmark.seal.fill")
+            .font(.callout).foregroundStyle(.green).fixedSize(horizontal: false, vertical: true)
+        verifyStep(c, 1, optional: true)
+        lockdownStep(c, 2)
+    }
+
+    @ViewBuilder
+    private func freshContent(_ c: AppState.MigrationCandidate) -> some View {
+        Text("Adds a fob key **alongside** your existing key on `\(c.destination)`. Your current key keeps working until you choose to retire it below.")
+            .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+
+        // Step 1 — install on the server
+        step(1, "Install the fob key on the server") {
+            if install == nil {
+                Toggle("Touch ID only (currently enrolled fingerprints)", isOn: $biometry)
+                    .toggleStyle(.checkbox).font(.callout)
+            }
+            switch install {
+            case nil, .error:
+                if case .error(let msg) = install {
+                    Label(msg, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
+                }
+                Button(busy ? "Installing…" : "Migrate \(alias)") { runInstall(c) }
+                    .disabled(busy).buttonStyle(.borderedProminent)
+            case .done(let msg):
+                Label(msg, systemImage: "checkmark.circle.fill").font(.callout).foregroundStyle(.green)
+            case .manual(let cmd, let detail):
+                Text(HostSetup.installFailureHint(detail))
+                    .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                copyBox(cmd)
+                if !detail.isEmpty {
+                    DisclosureGroup("Why it failed") {
+                        Text(detail)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.secondary).textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                            .background(RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.1)))
+                    }
+                    .font(.caption)
+                }
+                HStack {
+                    Button("Open in Terminal") { openInTerminal(cmd) }
+                    Button(busy ? "Checking…" : "Retry headless") { runInstall(c) }.disabled(busy)
+                    Button("I ran it — continue") { install = .done("Installed manually.") }
+                }
+            }
+        }
+
+        // Step 2 — config edit (diff + backup + apply)
+        if canShowApply {
+            step(2, "Update ~/.ssh/config") {
+                if let (_, _) = state.configDiff(alias: alias), applied?.ok != true {
+                    diffPreview()
+                    Button("Back up & apply") { runApply() }.buttonStyle(.borderedProminent).disabled(busy)
+                } else if applied?.ok == true {
+                    Label(applied!.text, systemImage: "checkmark.circle.fill").font(.callout).foregroundStyle(.green)
+                } else {
+                    Text("Already routed through fob — nothing to change.").font(.caption).foregroundStyle(.secondary)
+                }
+                if let applied, !applied.ok {
+                    Label(applied.text, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+
+        // Step 3 — verify
+        if canShowVerify { verifyStep(c, 3, optional: false) }
+
+        // Step 4 — pin + retire (only after a green verify)
+        if verified?.ok == true { lockdownStep(c, 4) }
+    }
+
+    @ViewBuilder
+    private func verifyStep(_ c: AppState.MigrationCandidate, _ n: Int, optional: Bool) -> some View {
+        step(n, optional ? "Re-verify fob works (optional)" : "Verify fob works (Touch ID)") {
+            Button(busy ? "Connecting…" : "Verify \(alias)") { runVerify(c) }
+                .disabled(busy).buttonStyle(.borderedProminent)
+            if let verified {
+                Label(verified.text, systemImage: verified.ok ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(verified.ok ? .green : .red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func lockdownStep(_ c: AppState.MigrationCandidate, _ n: Int) -> some View {
+        step(n, "Lock it down") {
+            HStack(spacing: 10) {
+                Button(pinned ? "Pinned ✓" : "Pin \(alias) → \(c.host)") { runPin(c) }.disabled(pinned)
+                if let pinNote {
+                    Text(pinNote).font(.caption).foregroundStyle(pinned ? .green : .orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            if !c.oldIdentityFiles.isEmpty {
+                Divider().padding(.vertical, 2)
+                Text("Comment out the old key in ~/.ssh/config now that fob is verified. It stays on the server's authorized_keys until you remove it there.")
+                    .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 10) {
+                    Button(retired?.ok == true ? "Retired ✓" : "Retire old key") { runRetire() }
+                        .disabled(retired?.ok == true || busy)
+                    if let retired {
+                        Text(retired.text).font(.caption)
+                            .foregroundStyle(retired.ok ? .green : .red).fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            } else {
+                Text("No local old key left to retire. If one is still on the server's authorized_keys, remove it there.")
+                    .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: Stage gating
+
+    private var installedOK: Bool {
+        if case .done = install { return true }
+        return false
+    }
+    private var canShowApply: Bool { installedOK }
+    private var canShowVerify: Bool {
+        installedOK && (applied?.ok == true || state.configDiff(alias: alias) == nil)
+    }
+
+    // MARK: Actions
+
+    private func runInstall(_ c: AppState.MigrationCandidate) {
+        busy = true
+        Task {
+            let outcome = await state.createAndInstall(c, requireBiometry: biometry)
+            switch outcome {
+            case .installed: install = .done("fob key installed on \(c.host).")
+            case .alreadyPresent: install = .done("fob key already on \(c.host).")
+            case .needsManual(let cmd, let detail): install = .manual(command: cmd, detail: detail)
+            case .failed(let msg): install = .error(msg)
+            }
+            busy = false
+        }
+    }
+
+    private func runApply() {
+        busy = true
+        switch state.applyConfigMigration(alias: alias) {
+        case .ok(let backup): applied = Status(ok: true, text: "Applied · backup \(backup)")
+        case .error(let msg): applied = Status(ok: false, text: msg)
+        }
+        busy = false
+    }
+
+    private func runVerify(_ c: AppState.MigrationCandidate) {
+        busy = true
+        Task {
+            if let msg = await state.verifyMigration(c) {
+                verified = Status(ok: false, text: msg)
+            } else {
+                verified = Status(ok: true, text: "fob works for \(c.destination). Your old key is still a fallback.")
+            }
+            busy = false
+        }
+    }
+
+    private func runPin(_ c: AppState.MigrationCandidate) {
+        if let msg = state.pinHost(alias: c.alias, host: c.host, port: c.port) {
+            pinNote = msg; pinned = false
+        } else {
+            pinned = true; pinNote = "Pinned — \(c.alias) will refuse any other host."
+        }
+    }
+
+    private func runRetire() {
+        switch state.retireOldKey(alias: alias) {
+        case .ok(let backup): retired = Status(ok: true, text: "Old key commented out · backup \(backup)")
+        case .error(let msg): retired = Status(ok: false, text: msg)
+        }
+    }
+
+    // MARK: Diff preview
+
+    @ViewBuilder
+    private func diffPreview() -> some View {
+        if let (old, new) = state.configDiff(alias: alias) {
+            let lines = TextDiff.lines(old: old, new: new)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { _, line in
+                        diffRow(line)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxHeight: 180)
+            .padding(8)
+            .background(RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.1)))
+        }
+    }
+
+    private func diffRow(_ line: TextDiff.Line) -> some View {
+        let (prefix, color): (String, Color) = {
+            switch line.kind {
+            case .added: return ("+", .green)
+            case .removed: return ("-", .red)
+            case .same: return (" ", .secondary)
+            }
+        }()
+        return Text("\(prefix) \(line.text)")
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(line.kind == .same ? Color.secondary : color)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+    }
+
+    // MARK: Building blocks
+
+    @ViewBuilder
+    private func step<Content: View>(_ n: Int, _ title: String, @ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("\(n). \(title)").font(.callout.weight(.semibold))
+            content()
+        }
+    }
+
+    private func copyBox(_ text: String) -> some View {
+        HStack(spacing: 8) {
+            Text(text).font(.system(.caption, design: .monospaced)).textSelection(.enabled)
+                .padding(8).frame(maxWidth: .infinity, alignment: .leading)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.12)))
+            Button("Copy") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+            }
+        }
+    }
+
+    /// Open Terminal.app running `command`. The command is fob-built from validated
+    /// tokens (alias/path), so there's no untrusted interpolation.
+    private func openInTerminal(_ command: String) {
+        let escaped = command.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let script = "tell application \"Terminal\" to do script \"\(escaped)\""
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+        try? process.run()
+    }
+}

--- a/Sources/FobApp/MigrateView.swift
+++ b/Sources/FobApp/MigrateView.swift
@@ -1,0 +1,104 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The "Migrate to fob" window: lists the servers already in ~/.ssh/config and starts a
+/// per-host migration. Servers are the focus; commit signing is surfaced only as a
+/// pointer to the ••• → "Use for commit signing…" flow.
+struct MigrateView: View {
+    static let windowID = "fob-migrate"
+
+    @EnvironmentObject var state: AppState
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
+
+    @State private var servers: [AppState.MigrationCandidate] = []
+    @State private var signing: GitConfig.SigningInfo?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Migrate to fob").font(.title2.weight(.semibold))
+            }
+
+            Text("fob adds a new Secure Enclave key **alongside** each existing key, proves it works, then lets you retire the old one. Your current keys keep working the whole time — no lockout.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+
+            if servers.isEmpty {
+                Text("No `Host` entries found in ~/.ssh/config. Add one with “Set up a host”, then come back here.")
+                    .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            } else {
+                Text("SERVERS IN ~/.ssh/config").font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary).tracking(0.6)
+                VStack(spacing: 0) {
+                    ForEach(Array(servers.enumerated()), id: \.element.id) { index, s in
+                        serverRow(s)
+                        if index < servers.count - 1 { Divider() }
+                    }
+                }
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+            }
+
+            if let signing { signingLine(signing) }
+
+            HStack {
+                Button("Refresh") { load() }
+                Spacer()
+                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(22)
+        .frame(width: 480)
+        .onAppear(perform: load)
+    }
+
+    private func load() {
+        servers = state.discoverServers()
+        signing = state.gitSigningInfo()
+    }
+
+    private func serverRow(_ s: AppState.MigrationCandidate) -> some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(s.alias).font(.callout.weight(.semibold))
+                Text(s.destination).font(.system(.caption, design: .monospaced)).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if s.usesFob && !s.oldIdentityFiles.isEmpty {
+                // Migrated but the old key is still active — let them come back to retire it.
+                HStack(spacing: 8) {
+                    Label("Using fob", systemImage: "checkmark.seal.fill").font(.caption).foregroundStyle(.green)
+                    Button("Retire old key…") { openMigrate(s.alias) }
+                }
+            } else if s.usesFob {
+                Label("Using fob", systemImage: "checkmark.seal.fill")
+                    .font(.caption).foregroundStyle(.green)
+            } else {
+                Button("Migrate…") { openMigrate(s.alias) }
+            }
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+    }
+
+    private func openMigrate(_ alias: String) {
+        state.migrateAlias = alias
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: MigrateHostView.windowID)
+    }
+
+    @ViewBuilder
+    private func signingLine(_ info: GitConfig.SigningInfo) -> some View {
+        Divider()
+        Group {
+            if info.usesFob {
+                Label("Commit signing already uses a fob key.", systemImage: "signature")
+            } else if info.signingKey != nil || info.format != nil {
+                Label("Commit signing uses a non-fob key — move it via a key's ••• → “Use for commit signing…”.", systemImage: "signature")
+            } else {
+                Label("To sign commits with fob, use a key's ••• → “Use for commit signing…”.", systemImage: "signature")
+            }
+        }
+        .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+    }
+}

--- a/Sources/FobKit/GitConfig.swift
+++ b/Sources/FobKit/GitConfig.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Minimal read-only parse of `~/.gitconfig` for the migration discovery view. We only
+/// need to tell the user whether commit signing is already configured and, if so, whether
+/// it's already a fob key — everything here is informational (servers are the priority).
+public enum GitConfig {
+    public struct SigningInfo: Equatable {
+        public let format: String?      // gpg.format (e.g. "ssh")
+        public let signingKey: String?  // user.signingkey
+        public let usesFob: Bool        // signingkey points at a fob key/socket
+
+        public init(format: String?, signingKey: String?, usesFob: Bool) {
+            self.format = format
+            self.signingKey = signingKey
+            self.usesFob = usesFob
+        }
+    }
+
+    /// Parse the `[gpg] format` and `[user] signingkey` values out of gitconfig text.
+    /// Tolerates subsection headers (`[gpg "ssh"]`) — only the bare `[gpg]`/`[user]`
+    /// sections carry the keys we read.
+    public static func parse(_ gitconfig: String) -> SigningInfo {
+        var section = ""
+        var format: String?
+        var signingKey: String?
+        for raw in gitconfig.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("[") && line.contains("]") {
+                let header = line.dropFirst().prefix(while: { $0 != "]" })
+                // Section name is the first token before any quoted subsection.
+                section = header.split(whereSeparator: { $0 == " " || $0 == "\t" })
+                    .first.map(String.init)?.lowercased() ?? ""
+                continue
+            }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let key = line[..<eq].trimmingCharacters(in: .whitespaces).lowercased()
+            let value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if section == "gpg" && key == "format" { format = value }
+            if section == "user" && key == "signingkey" { signingKey = value }
+        }
+        let key = signingKey ?? ""
+        let usesFob = key.contains("/fob_") || key.contains("/.fob/")
+        return SigningInfo(format: format, signingKey: signingKey, usesFob: usesFob)
+    }
+}

--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -38,6 +38,26 @@ public enum HostSetup {
         public var port: Int?
         public var identityFiles: [String]
         public var usesFobAgent: Bool // IdentityAgent already points at ~/.fob/agent.sock
+
+        public init(hostName: String?, user: String?, port: Int?,
+                    identityFiles: [String], usesFobAgent: Bool) {
+            self.hostName = hostName
+            self.user = user
+            self.port = port
+            self.identityFiles = identityFiles
+            self.usesFobAgent = usesFobAgent
+        }
+    }
+
+    /// One migratable host discovered in `~/.ssh/config`.
+    public struct HostBlock: Equatable {
+        public let alias: String
+        public let parsed: ParsedHost
+        public init(alias: String, parsed: ParsedHost) {
+            self.alias = alias
+            self.parsed = parsed
+        }
+        public var usesFob: Bool { parsed.usesFobAgent }
     }
 
     /// Reads the `Host <alias>` block from ssh-config text, if the alias appears as a
@@ -74,5 +94,243 @@ public enum HostSetup {
             }
         }
         return found ? host : nil
+    }
+
+    // MARK: - Migration (fob adopt / the app's migrate flow)
+
+    /// Enumerate every *literal* `Host <alias>` block in the config (skipping wildcard
+    /// and `Match` blocks, same rule as `parseHostBlock`). A `Host a b` line yields one
+    /// entry per literal token. Used to build the migration candidate list.
+    public static func listHostBlocks(in config: String) -> [HostBlock] {
+        var out: [HostBlock] = []
+        var seen = Set<String>()
+        for raw in config.split(separator: "\n") {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            guard line.lowercased().hasPrefix("host ") else { continue }
+            let tokens = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).dropFirst().map(String.init)
+            for token in tokens {
+                // Skip ssh pattern tokens — we only touch a plain, literal alias.
+                if token.contains("*") || token.contains("?") || token.hasPrefix("!") { continue }
+                if seen.contains(token) { continue }
+                seen.insert(token)
+                if let parsed = parseHostBlock(alias: token, in: config) {
+                    out.append(HostBlock(alias: token, parsed: parsed))
+                }
+            }
+        }
+        return out
+    }
+
+    /// True if an `IdentityFile`/`IdentityAgent` value belongs to fob.
+    private static func isFobIdentity(_ value: String) -> Bool {
+        value.contains("/fob_") || value.contains("/.fob/")
+    }
+
+    /// The risky transform: edit the existing `Host <alias>` block in place to route it
+    /// through fob. Adds `IdentityAgent`/`IdentityFile`/`IdentitiesOnly yes` (only the
+    /// ones missing) and comments out any non-fob `IdentityAgent`. The old `IdentityFile`
+    /// is left ACTIVE (fob is preferred, the old key is the fallback — no lockout) unless
+    /// `retireOld` is true, in which case it is commented out.
+    ///
+    /// Returns nil if there's no literal `Host <alias>` block. Idempotent: returns the
+    /// input unchanged when there's nothing left to do. Never touches other blocks,
+    /// `HostName`/`User`/`Port`, or `Match`/wildcard sections.
+    public static func migratedConfig(_ config: String, alias: String,
+                                      fobPubPath: String, socketPath: String,
+                                      retireOld: Bool = false) -> String? {
+        // components/joined round-trips exactly, so untouched bytes are preserved.
+        var lines = config.components(separatedBy: "\n")
+
+        func isSectionStart(_ raw: String) -> Bool {
+            let l = raw.trimmingCharacters(in: .whitespaces).lowercased()
+            return l == "host" || l.hasPrefix("host ") || l == "match" || l.hasPrefix("match ")
+        }
+        func keyValue(_ raw: String) -> (key: String, value: String)? {
+            let t = raw.trimmingCharacters(in: .whitespaces)
+            if t.isEmpty || t.hasPrefix("#") { return nil }
+            guard let sep = t.firstIndex(where: { $0 == " " || $0 == "\t" || $0 == "=" }) else { return nil }
+            let key = t[..<sep].lowercased()
+            let value = t[t.index(after: sep)...].trimmingCharacters(in: CharacterSet(charactersIn: " \t=\""))
+            return (key, value)
+        }
+
+        // 1. Locate the literal block for `alias`.
+        var start: Int?
+        for (i, raw) in lines.enumerated() {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            guard line.lowercased().hasPrefix("host ") else { continue }
+            let tokens = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).dropFirst().map(String.init)
+            if tokens.contains(alias) { start = i; break }
+        }
+        guard let blockStart = start else { return nil }
+
+        // 2. Block end = next Host/Match, else EOF.
+        var end = lines.count
+        var k = blockStart + 1
+        while k < lines.count {
+            if isSectionStart(lines[k]) { end = k; break }
+            k += 1
+        }
+
+        // 3. Indent from the first indented directive; default two spaces.
+        var indent = "  "
+        for i in (blockStart + 1)..<end {
+            let trimmed = lines[i].trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+            let leading = String(lines[i].prefix(while: { $0 == " " || $0 == "\t" }))
+            if !leading.isEmpty { indent = leading }
+            break
+        }
+
+        // 4. Scan the body.
+        var hasFobAgent = false, hasFobIdentityFile = false, hasIdentitiesOnly = false
+        var nonFobAgentIdxs: [Int] = [], nonFobIdentityFileIdxs: [Int] = []
+        var lastDirectiveIdx = blockStart
+        var firstIdentityFileIdx: Int?   // insert fob BEFORE this, so fob is preferred
+        for i in (blockStart + 1)..<end {
+            guard let (key, value) = keyValue(lines[i]) else { continue }
+            lastDirectiveIdx = i
+            switch key {
+            case "identityagent":
+                if isFobIdentity(value) || value == socketPath { hasFobAgent = true }
+                else { nonFobAgentIdxs.append(i) }
+            case "identityfile":
+                if firstIdentityFileIdx == nil { firstIdentityFileIdx = i }
+                if value == fobPubPath || isFobIdentity(value) { hasFobIdentityFile = true }
+                else { nonFobIdentityFileIdxs.append(i) }
+            case "identitiesonly":
+                if value.lowercased() == "yes" { hasIdentitiesOnly = true }
+            default: break
+            }
+        }
+
+        // 5. Idempotency: nothing to add and (not retiring, or nothing left to retire).
+        if hasFobAgent && hasFobIdentityFile && hasIdentitiesOnly
+            && (!retireOld || nonFobIdentityFileIdxs.isEmpty) {
+            return config
+        }
+
+        // 6. Comment out lines in place (no index shift).
+        func commentOut(_ i: Int, suffix: String = "") {
+            let leading = String(lines[i].prefix(while: { $0 == " " || $0 == "\t" }))
+            lines[i] = leading + "# " + lines[i].dropFirst(leading.count) + suffix
+        }
+        for i in nonFobAgentIdxs { commentOut(i) }
+        if retireOld {
+            for i in nonFobIdentityFileIdxs {
+                commentOut(i, suffix: "   # disabled by fob after verified migration")
+            }
+        }
+
+        // 7. Insert the missing fob directives. Place them BEFORE the first existing
+        //    IdentityFile so ssh offers fob first (Touch ID), falling back to the old key
+        //    only if fob is unavailable. With no IdentityFile in the block, append them.
+        var toInsert: [String] = []
+        if !hasFobAgent { toInsert.append(indent + "IdentityAgent " + socketPath) }
+        if !hasFobIdentityFile { toInsert.append(indent + "IdentityFile " + fobPubPath) }
+        if !hasIdentitiesOnly { toInsert.append(indent + "IdentitiesOnly yes") }
+        if !toInsert.isEmpty {
+            lines.insert(contentsOf: toInsert, at: firstIdentityFileIdx ?? (lastDirectiveIdx + 1))
+        }
+
+        var result = lines.joined(separator: "\n")
+        // Normalize: an edited file should end in exactly one newline.
+        if !result.isEmpty && !result.hasSuffix("\n") { result += "\n" }
+        return result
+    }
+
+    /// Shell run on the server (over the user's CURRENT key) to append the fob public
+    /// key to `authorized_keys`, idempotently. The pub line is piped on stdin. Prints
+    /// `fob-installed` or `fob-present` on success.
+    public static let remoteAppendScript =
+        #"umask 077; mkdir -p ~/.ssh; k="$(cat)"; touch ~/.ssh/authorized_keys; "#
+        + #"if grep -qxF "$k" ~/.ssh/authorized_keys; then echo fob-present; "#
+        + #"else printf '%s\n' "$k" >> ~/.ssh/authorized_keys && echo fob-installed; fi"#
+
+    /// ssh argv (for `/usr/bin/ssh`) to install the fob key headless, authenticating with
+    /// the host's existing key. Returns nil for an unsafe alias (leading '-' etc.) so it
+    /// can never be parsed as an ssh option. Pass the fob pub line on the child's stdin.
+    public static func installArguments(alias: String) -> [String]? {
+        guard isValidHostToken(alias) else { return nil }
+        return ["-o", "BatchMode=yes",
+                "-o", "ConnectTimeout=10",
+                "-o", "StrictHostKeyChecking=accept-new",
+                alias, remoteAppendScript]
+    }
+
+    /// The manual fallback shown when the headless install can't run (passphrase-locked
+    /// old key, unreachable host, …). ssh-copy-id gets a real TTY for the prompt.
+    public static func fallbackCopyCommand(alias: String, fobPubPath: String, port: Int) -> String {
+        // -f is required: fob keys have no private file on disk (it's in the enclave),
+        // and without -f ssh-copy-id tries to derive from a private key it can't find.
+        var parts = ["ssh-copy-id", "-f", "-i", fobPubPath]
+        if port != 22 { parts += ["-p", String(port)] }
+        parts.append(alias)
+        return parts.joined(separator: " ")
+    }
+
+    /// Turn a failed headless-install ssh error into a plain-language reason + what to do.
+    /// The headless install runs with `BatchMode=yes`, so a passphrase-protected key (not
+    /// loaded in ssh-agent) can't be unlocked and the server reports "Permission denied".
+    public static func installFailureHint(_ output: String) -> String {
+        let o = output.lowercased()
+        if o.contains("permission denied") {
+            return "Your existing key couldn't be used automatically — most likely it needs a "
+                + "passphrase (and isn't loaded in ssh-agent), which the non-interactive install "
+                + "can't enter. Run it in a terminal (you'll be asked for the passphrase), or "
+                + "`ssh-add` the key and Retry headless:"
+        }
+        if o.contains("could not resolve") || o.contains("no route to host")
+            || o.contains("timed out") || o.contains("connection refused") {
+            return "The host couldn't be reached from here — check your network, then run it in a terminal:"
+        }
+        if o.contains("host key verification failed") {
+            return "The host key didn't match ~/.ssh/known_hosts. Resolve that, then run it in a terminal:"
+        }
+        return "Couldn't install headlessly (the host may be unreachable, or your key needs a "
+            + "passphrase). Run this in a terminal — it uses your existing key, no fob needed yet:"
+    }
+
+    /// Make untrusted subprocess output (an ssh/server error) safe to show in the UI:
+    /// drop control characters and escape sequences, keep only the last few lines, and
+    /// cap the length. It's only ever rendered as text, never executed — this just keeps
+    /// a hostile server from spamming the UI with control bytes or huge output.
+    public static func sanitizeForDisplay(_ s: String, maxLines: Int = 6, maxChars: Int = 600) -> String {
+        let scalars = s.unicodeScalars.filter {
+            $0 == "\n" || $0 == "\t" || ($0.value >= 0x20 && $0.value != 0x7f)
+        }
+        var text = String(String.UnicodeScalarView(scalars))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        if lines.count > maxLines { text = lines.suffix(maxLines).joined(separator: "\n") }
+        if text.count > maxChars { text = "…" + text.suffix(maxChars) }
+        return text
+    }
+
+    /// Backup name for `~/.ssh/config`, e.g. `config.fob-backup-20260711-094512`.
+    public static func backupName(now: Date) -> String {
+        let fmt = DateFormatter()
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = .current
+        fmt.dateFormat = "yyyyMMdd-HHmmss"
+        return "config.fob-backup-\(fmt.string(from: now))"
+    }
+
+    /// Copy the current `~/.ssh/config` to a timestamped 0600 backup, then atomically
+    /// write `newText` (also 0600). Returns the backup URL (or the intended path when the
+    /// config didn't exist yet). The backup is the undo path if a migration misbehaves.
+    @discardableResult
+    public static func backupAndWriteConfig(_ newText: String, at configURL: URL,
+                                            now: Date = Date()) throws -> URL {
+        let fm = FileManager.default
+        let backupURL = configURL.deletingLastPathComponent().appendingPathComponent(backupName(now: now))
+        if fm.fileExists(atPath: configURL.path) {
+            if fm.fileExists(atPath: backupURL.path) { try fm.removeItem(at: backupURL) }
+            try fm.copyItem(at: configURL, to: backupURL)
+            try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
+        }
+        try Data(newText.utf8).write(to: configURL, options: .atomic)
+        try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
+        return backupURL
     }
 }

--- a/Sources/FobKit/TextDiff.swift
+++ b/Sources/FobKit/TextDiff.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// A minimal line diff (LCS) used to preview exactly what a migration will change in
+/// `~/.ssh/config` before it's written — so the user confirms a diff, never a black box.
+public enum TextDiff {
+    public enum Kind: Equatable { case same, added, removed }
+
+    public struct Line: Equatable {
+        public let kind: Kind
+        public let text: String
+        public init(_ kind: Kind, _ text: String) {
+            self.kind = kind
+            self.text = text
+        }
+    }
+
+    /// Line-by-line diff of `old` → `new` via a longest-common-subsequence walk.
+    public static func lines(old: String, new: String) -> [Line] {
+        let a = old.components(separatedBy: "\n")
+        let b = new.components(separatedBy: "\n")
+        let n = a.count, m = b.count
+
+        // dp[i][j] = LCS length of a[i...] and b[j...].
+        var dp = Array(repeating: Array(repeating: 0, count: m + 1), count: n + 1)
+        if n > 0 && m > 0 {
+            for i in stride(from: n - 1, through: 0, by: -1) {
+                for j in stride(from: m - 1, through: 0, by: -1) {
+                    dp[i][j] = a[i] == b[j] ? dp[i + 1][j + 1] + 1 : max(dp[i + 1][j], dp[i][j + 1])
+                }
+            }
+        }
+
+        var out: [Line] = []
+        var i = 0, j = 0
+        while i < n && j < m {
+            if a[i] == b[j] { out.append(Line(.same, a[i])); i += 1; j += 1 }
+            else if dp[i + 1][j] >= dp[i][j + 1] { out.append(Line(.removed, a[i])); i += 1 }
+            else { out.append(Line(.added, b[j])); j += 1 }
+        }
+        while i < n { out.append(Line(.removed, a[i])); i += 1 }
+        while j < m { out.append(Line(.added, b[j])); j += 1 }
+        return out
+    }
+}

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -4,26 +4,49 @@ import Foundation
 /// Guided end-to-end setup for one remote host: create (or reuse) an enclave key,
 /// export its public key, install it on the server, wire up ~/.ssh/config, verify.
 enum Setup {
-    /// `fob adopt <alias>` — convert an existing `~/.ssh/config` host to fob. Prints a
-    /// dry-run plan (generates the enclave key locally, but changes nothing on the
-    /// server or in ~/.ssh/config); the key install leans on your existing key auth,
-    /// so it's passwordless for hosts you can already reach.
+    /// `fob adopt <alias>` — convert an existing `~/.ssh/config` host to fob. By default it
+    /// performs the migration: installs the fob key on the server using your EXISTING key
+    /// (passwordless), previews + backs up + rewrites ~/.ssh/config, verifies over Touch ID,
+    /// and pins. The old key stays active as a fallback until you `--retire` it. `--dry-run`
+    /// prints the plan and changes nothing.
     static func adopt(store: KeyStore, arguments: [String]) throws {
         var rest = arguments
         let requireBiometry = rest.contains("--require-biometry")
-        rest.removeAll { $0 == "--require-biometry" }
+        let dryRun = rest.contains("--dry-run")
+        let retire = rest.contains("--retire")
+        rest.removeAll { $0.hasPrefix("--") }
         guard rest.count == 1, let alias = rest.first, KeyStore.isValidName(alias) else {
             throw AdoptError.usage
         }
 
         let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
-        let configText = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
+        let configURL = sshDir.appendingPathComponent("config")
+        let configText = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
         guard let parsed = HostSetup.parseHostBlock(alias: alias, in: configText) else {
             throw AdoptError.notConfigured(alias)
         }
         let host = parsed.hostName ?? alias
         let user = parsed.user ?? NSUserName()
         let port = parsed.port ?? 22
+        let pubURL = sshDir.appendingPathComponent("fob_\(alias).pub")
+        let old = parsed.identityFiles.first(where: { !$0.contains("/fob_") })
+        let isGitProvider = ["github.com", "gitlab.com", "bitbucket.org", "ssh.github.com"].contains(host.lowercased())
+
+        // `--retire`: just comment out the old IdentityFile (run after a verified migration).
+        if retire {
+            guard let newConfig = HostSetup.migratedConfig(configText, alias: alias,
+                                                           fobPubPath: pubURL.path, socketPath: store.socketPath,
+                                                           retireOld: true), newConfig != configText else {
+                print("Nothing to retire — no active non-fob IdentityFile in `Host \(alias)`.")
+                return
+            }
+            printDiff(configText, newConfig)
+            guard confirm("Comment out the old key in ~/.ssh/config?") else { print("Cancelled."); return }
+            let backup = try HostSetup.backupAndWriteConfig(newConfig, at: configURL)
+            print("Retired. Backup: \(backup.lastPathComponent)")
+            print("Now remove the old key from the server: edit ~/.ssh/authorized_keys on \(host).")
+            return
+        }
 
         if parsed.usesFobAgent {
             print("`\(alias)` already routes through fob (its IdentityAgent is ~/.fob/agent.sock).")
@@ -40,48 +63,134 @@ enum Setup {
             key = try store.create(name: alias, requireBiometry: requireBiometry)
             print("Created Secure Enclave key '\(alias)' (\(requireBiometry ? "Touch ID only" : "Touch ID, Apple Watch, or password")).")
         }
-        let pubURL = sshDir.appendingPathComponent("fob_\(alias).pub")
         let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(alias)")
         try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
-
-        let portArg = port == 22 ? "" : " -p \(port)"
-        let old = parsed.identityFiles.first(where: { !$0.contains("/fob_") })
-        let isGitProvider = ["github.com", "gitlab.com", "bitbucket.org", "ssh.github.com"].contains(host.lowercased())
-
-        print("")
-        print("Adopting `\(alias)` (\(user)@\(host)\(port == 22 ? "" : ":\(port)")) into fob.")
         print("Public key exported to \(pubURL.path).")
+
+        let newConfig = HostSetup.migratedConfig(configText, alias: alias,
+                                                 fobPubPath: pubURL.path, socketPath: store.socketPath)
+
+        if dryRun {
+            printDryRun(alias: alias, host: host, user: user, port: port, pubLine: pubLine,
+                        pubPath: pubURL.path, socketPath: store.socketPath, old: old,
+                        isGitProvider: isGitProvider, newConfig: newConfig, currentConfig: configText)
+            return
+        }
+
+        // 1. Install the fob key on the server, authenticating with your current key.
+        let portArg = port == 22 ? [] : ["-p", String(port)]
+        if isGitProvider {
+            print("")
+            print("\(host) is a git host — add this key to your account (Settings → SSH keys):")
+            print("     \(pubLine)")
+            print("(then the config change below routes ssh through fob)")
+        } else {
+            guard hasControllingTerminal() else {
+                print("No terminal for ssh-copy-id's prompts — run in a real terminal, or use --dry-run.")
+                throw SetupError.copyFailed
+            }
+            print("")
+            print("Installing the fob key on \(alias) using your current key…")
+            let status = runInteractive("/usr/bin/ssh-copy-id", ["-f", "-i", pubURL.path] + portArg + [alias])
+            guard status == 0 else {
+                print("ssh-copy-id failed. Retry: ssh-copy-id -f -i \(pubURL.path) \(portArg.joined(separator: " ")) \(alias)")
+                throw SetupError.copyFailed
+            }
+        }
+
+        // 2. Rewrite ~/.ssh/config (preview + backup + confirm).
+        if let newConfig, newConfig != configText {
+            print("")
+            printDiff(configText, newConfig)
+            guard confirm("Apply this change to ~/.ssh/config?") else {
+                print("Skipped — copy the lines above into `Host \(alias)` yourself.")
+                return
+            }
+            let backup = try HostSetup.backupAndWriteConfig(newConfig, at: configURL)
+            print("Applied. Backup: \(backup.lastPathComponent)")
+        } else {
+            print("~/.ssh/config already routes \(alias) through fob.")
+        }
+
+        // 3. Verify (servers only — a git host needs the key added first).
+        if isGitProvider {
+            print("")
+            print("Test after adding the key to \(host):  ssh -T \(alias)")
+        } else if confirm("Test the connection now? (Touch ID will prompt)") {
+            let args = ["-o", "ConnectTimeout=10", "-o", "IdentitiesOnly=yes",
+                        "-o", "IdentityAgent=\(store.socketPath)", "-i", pubURL.path]
+                + portArg + ["\(user)@\(host)", "true"]
+            if runInteractive("/usr/bin/ssh", args) == 0 {
+                print("✅ fob works for \(alias). Your old key is still a fallback.")
+            } else {
+                print("Test failed — your old key still works and nothing was removed.")
+                return
+            }
+        }
+
+        // 4. Pin to this host (the connection just populated known_hosts).
+        let hostKeys = HostResolver.knownHostKeys(for: host, port: port)
+        if hostKeys.isEmpty {
+            print("Not in known_hosts yet — pin later with: fob pin \(alias) \(host)")
+        } else {
+            var policy = store.policy(name: alias)
+            policy.pinnedHostKeys.append(contentsOf: hostKeys.filter { !policy.pinnedHostKeys.contains($0) })
+            try store.savePolicy(policy, name: alias)
+            print("🔒 Pinned \(alias) to \(host) — undo with: fob unpin \(alias)")
+        }
+
+        // 5. Offer retire.
+        if old != nil {
+            print("")
+            print("Once you're confident, retire the old key:")
+            print("  fob adopt \(alias) --retire      # comment it out of ~/.ssh/config")
+            print("  then remove it from the server's ~/.ssh/authorized_keys")
+        }
+    }
+
+    /// Print the dry-run plan for `adopt` — nothing is executed.
+    private static func printDryRun(alias: String, host: String, user: String, port: Int,
+                                    pubLine: String, pubPath: String, socketPath: String,
+                                    old: String?, isGitProvider: Bool,
+                                    newConfig: String?, currentConfig: String) {
         print("")
-        print("Dry run — nothing on the server or in ~/.ssh/config was changed. To convert,")
-        print("run these steps (they use your EXISTING key, so no password is needed):")
+        print("Dry run for `\(alias)` (\(user)@\(host)\(port == 22 ? "" : ":\(port)")) — nothing was changed.")
+        print("Run without --dry-run to perform these steps (they use your EXISTING key):")
         print("")
         if isGitProvider {
             print("1. Add the fob public key to your \(host) account (Settings → SSH keys):")
-            print("")
             print("     \(pubLine)")
         } else {
-            print("1. Install the fob key on the server (authenticates with your current key):")
-            print("")
-            print("     ssh-copy-id -f -i \(pubURL.path)\(portArg) \(alias)")
+            let portArg = port == 22 ? "" : " -p \(port)"
+            print("1. Install the fob key on the server:")
+            print("     ssh-copy-id -f -i \(pubPath)\(portArg) \(alias)")
         }
         print("")
-        print("2. Point `Host \(alias)` in ~/.ssh/config at fob — ensure these lines are in")
-        print("   the block\(old.map { ", and comment out the old `IdentityFile \($0)`" } ?? ""):")
+        print("2. Rewrite `Host \(alias)` in ~/.ssh/config:")
+        if let newConfig, newConfig != currentConfig {
+            printDiff(currentConfig, newConfig)
+        } else {
+            print("   (already routes through fob)")
+        }
         print("")
-        print("     IdentityAgent \(store.socketPath)")
-        print("     IdentityFile \(pubURL.path)")
-        print("     IdentitiesOnly yes")
-        print("")
-        print("3. Test (Touch ID will prompt):")
-        print("")
-        print("     ssh \(alias) true")
-        print("")
-        print("4. Pin the key so it only works for this host:")
-        print("")
-        print("     fob pin \(alias) \(host)")
-        print("")
-        print("5. Once it works, remove the old key from \(isGitProvider ? "your \(host) account" : "the server's ~/.ssh/authorized_keys").")
+        print("3. Test:  ssh \(isGitProvider ? "-T " : "")\(alias)\(isGitProvider ? "" : " true")")
+        print("4. Pin:   fob pin \(alias) \(host)")
+        if old != nil {
+            print("5. When confident: fob adopt \(alias) --retire, then remove the old key on the server.")
+        }
+    }
+
+    /// Print a +/- unified diff of two config texts (only the changed region is interesting,
+    /// but showing context keeps it readable).
+    private static func printDiff(_ old: String, _ new: String) {
+        for line in TextDiff.lines(old: old, new: new) {
+            switch line.kind {
+            case .added: print("   + \(line.text)")
+            case .removed: print("   - \(line.text)")
+            case .same: print("     \(line.text)")
+            }
+        }
     }
 
     static func run(store: KeyStore, arguments: [String]) throws {
@@ -383,7 +492,7 @@ enum AdoptError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .usage:
-            return "usage: fob adopt <alias> [--require-biometry]"
+            return "usage: fob adopt <alias> [--dry-run] [--retire] [--require-biometry]"
         case .notConfigured(let alias):
             return "no `Host \(alias)` entry in ~/.ssh/config — for a brand-new host use: fob setup \(alias)"
         }

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -20,14 +20,19 @@ USAGE:
       commands for you to inspect and run yourself — nothing is executed
       and ~/.ssh/config is not touched.
 
-  fob adopt <alias> [--require-biometry]
-      Convert an existing ~/.ssh/config host to fob. Prints a dry-run plan
-      (generates the enclave key locally but changes nothing on the server or
-      in ~/.ssh/config); the install step reuses your current key, so it's
-      passwordless for hosts you can already reach.
+  fob adopt <alias> [--dry-run] [--retire] [--require-biometry]
+      Convert an existing ~/.ssh/config host to fob. Installs the fob key on the
+      server using your CURRENT key (passwordless), backs up + rewrites the config
+      block (with a diff + confirm), verifies over Touch ID, and pins. The old key
+      stays active as a fallback — no lockout. --dry-run prints the plan and changes
+      nothing; --retire comments out the old key after you've verified fob works.
 
   fob list
       Print the public keys in authorized_keys format.
+
+  fob delete <name> [--force]
+      Permanently erase a key from the Secure Enclave (asks to confirm; --force
+      skips). Remove its public key from any server/host that still trusts it.
 
   fob pin <name> <host>
       Pin a key to a host: the agent will refuse to sign with this key for
@@ -130,6 +135,23 @@ do {
         for key in keys {
             print(SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(key.name)"))
         }
+
+    case "delete":
+        var rest = Array(arguments.dropFirst())
+        let force = rest.contains("--force") || rest.contains("-y")
+        rest.removeAll { $0.hasPrefix("-") }
+        guard rest.count == 1, let name = rest.first else {
+            fail("usage: fob delete <name> [--force]")
+        }
+        _ = try store.find(name: name) // 404s cleanly before we prompt
+        if !force {
+            print("Delete key '\(name)'? The Secure Enclave key is erased permanently and "
+                + "cannot be recovered. [y/N]: ", terminator: "")
+            let answer = readLine()?.trimmingCharacters(in: .whitespaces).lowercased() ?? ""
+            guard answer == "y" || answer == "yes" else { print("Cancelled."); break }
+        }
+        try store.remove(name: name)
+        print("Deleted '\(name)'. Remove its public key from any server/host that still trusts it.")
 
     case "pin":
         let rest = Array(arguments.dropFirst())

--- a/Tests/FobKitTests/MigrationTests.swift
+++ b/Tests/FobKitTests/MigrationTests.swift
@@ -1,0 +1,281 @@
+import XCTest
+
+@testable import FobKit
+
+/// Golden + safety tests for the server-migration core in HostSetup, plus GitConfig /
+/// TextDiff. The config rewrite edits the user's ~/.ssh/config, so it's held to exact,
+/// byte-level expectations.
+final class MigrationTests: XCTestCase {
+    private let pub = "/Users/me/.ssh/fob_web.pub"
+    private let sock = "/Users/me/.fob/agent.sock"
+
+    private func migrate(_ config: String, alias: String = "web", retireOld: Bool = false) -> String? {
+        HostSetup.migratedConfig(config, alias: alias, fobPubPath: pub, socketPath: sock, retireOld: retireOld)
+    }
+
+    // 1. Old IdentityFile stays active; the three fob lines are added, fob PREFERRED
+    //    (listed before the old key so ssh tries fob first, old as fallback).
+    func testAddsFobLinesKeepsOldIdentity() {
+        let config = "Host web\n  HostName web.example\n  IdentityFile ~/.ssh/id_ed25519\n"
+        let out = migrate(config)!
+        XCTAssertTrue(out.contains("  IdentityFile ~/.ssh/id_ed25519\n"), "old key must stay active")
+        XCTAssertTrue(out.contains("  IdentityAgent \(sock)"))
+        XCTAssertTrue(out.contains("  IdentityFile \(pub)"))
+        XCTAssertTrue(out.contains("  IdentitiesOnly yes"))
+        let fobAt = out.range(of: "IdentityFile \(pub)")!.lowerBound
+        let oldAt = out.range(of: "IdentityFile ~/.ssh/id_ed25519")!.lowerBound
+        XCTAssertTrue(fobAt < oldAt, "fob key must be listed before the old key so it's preferred")
+        let agentAt = out.range(of: "IdentityAgent \(sock)")!.lowerBound
+        XCTAssertTrue(agentAt < oldAt, "fob agent must precede the old key")
+    }
+
+    // 2. Idempotent.
+    func testIdempotent() {
+        let config = "Host web\n  HostName web.example\n  IdentityFile ~/.ssh/id_ed25519\n"
+        let once = migrate(config)!
+        let twice = migrate(once)!
+        XCTAssertEqual(once, twice)
+    }
+
+    // 3. Custom Port preserved, no new Port line.
+    func testPreservesPort() {
+        let config = "Host web\n  HostName web.example\n  Port 2222\n  IdentityFile ~/.ssh/id\n"
+        let out = migrate(config)!
+        XCTAssertTrue(out.contains("  Port 2222\n"))
+        XCTAssertEqual(out.components(separatedBy: "Port 2222").count - 1, 1)
+    }
+
+    // 4. Unrelated blocks/comments preserved exactly.
+    func testUnrelatedBlocksUntouched() {
+        let config = """
+        # my ssh config
+        Host other
+          HostName other.example
+          IdentityFile ~/.ssh/other
+
+        Host web
+          HostName web.example
+          IdentityFile ~/.ssh/id
+
+        Host third
+          HostName third.example
+        """
+        let out = migrate(config)!
+        XCTAssertTrue(out.contains("# my ssh config\nHost other\n  HostName other.example\n  IdentityFile ~/.ssh/other\n"))
+        XCTAssertTrue(out.contains("Host third\n  HostName third.example"))
+        XCTAssertFalse(out.contains("other.example\n  IdentityAgent"), "other block must not get fob lines")
+    }
+
+    // 5. Host with no IdentityFile → only fob lines added, nothing commented.
+    func testNoIdentityFile() {
+        let config = "Host web\n  HostName web.example\n"
+        let out = migrate(config)!
+        XCTAssertTrue(out.contains("  IdentityAgent \(sock)"))
+        XCTAssertTrue(out.contains("  IdentityFile \(pub)"))
+        XCTAssertTrue(out.contains("  IdentitiesOnly yes"))
+        XCTAssertFalse(out.contains("# "), "nothing to comment out")
+    }
+
+    // 6. Partial migration: only the missing directive is added.
+    func testPartialMigrationAddsMissingOnly() {
+        let config = "Host web\n  HostName web.example\n  IdentityAgent \(sock)\n  IdentityFile \(pub)\n"
+        let out = migrate(config)!
+        XCTAssertEqual(out.components(separatedBy: "IdentityAgent").count - 1, 1)
+        XCTAssertEqual(out.components(separatedBy: "IdentityFile \(pub)").count - 1, 1)
+        XCTAssertTrue(out.contains("  IdentitiesOnly yes"))
+    }
+
+    // 7. '=' separator on the old IdentityFile is recognized (and retired correctly).
+    func testEqualsSeparatorRetire() {
+        let config = "Host web\n  HostName web.example\n  IdentityFile=~/.ssh/id\n"
+        let out = migrate(config, retireOld: true)!
+        XCTAssertTrue(out.contains("# IdentityFile=~/.ssh/id"), "old key should be commented under retire")
+        XCTAssertTrue(out.contains("disabled by fob"))
+    }
+
+    // 8. Multi-token Host line edits only the matched block.
+    func testMultiTokenHost() {
+        let config = "Host web web-old\n  HostName web.example\n  IdentityFile ~/.ssh/id\n\nHost api\n  HostName api.example\n"
+        let out = migrate(config, alias: "web-old")!
+        XCTAssertTrue(out.contains("Host web web-old\n"))
+        XCTAssertTrue(out.contains("  IdentityAgent \(sock)"))
+        XCTAssertFalse(out.contains("api.example\n  IdentityAgent"))
+    }
+
+    // 9. Non-fob IdentityAgent is commented out and the fob one added.
+    func testCommentsForeignIdentityAgent() {
+        let config = "Host web\n  HostName web.example\n  IdentityAgent /other/agent.sock\n"
+        let out = migrate(config)!
+        XCTAssertTrue(out.contains("# IdentityAgent /other/agent.sock"))
+        XCTAssertTrue(out.contains("  IdentityAgent \(sock)"))
+    }
+
+    // 10. Tab indentation preserved.
+    func testTabIndent() {
+        let config = "Host web\n\tHostName web.example\n\tIdentityFile ~/.ssh/id\n"
+        let out = migrate(config)!
+        XCTAssertTrue(out.contains("\tIdentityAgent \(sock)"), "should reuse the block's tab indent")
+    }
+
+    // 11. No trailing newline → output is normalized to end with one.
+    func testNoTrailingNewlineNormalized() {
+        let config = "Host web\n  HostName web.example\n  IdentityFile ~/.ssh/id"
+        let out = migrate(config)!
+        XCTAssertTrue(out.hasSuffix("\n"))
+    }
+
+    // 12. retireOld on an already-migrated-but-not-retired block comments the old key
+    //     and is itself idempotent.
+    func testRetireThenIdempotent() {
+        let config = "Host web\n  HostName web.example\n  IdentityFile ~/.ssh/id\n"
+        let migrated = migrate(config)!                     // fob added, old still active
+        XCTAssertTrue(migrated.contains("  IdentityFile ~/.ssh/id\n"))
+        let retired = migrate(migrated, retireOld: true)!   // now comment the old
+        XCTAssertTrue(retired.contains("# IdentityFile ~/.ssh/id"))
+        XCTAssertEqual(migrate(retired, retireOld: true)!, retired, "retire is idempotent")
+    }
+
+    // 13. Alias only under Host * / Match → nil (never touched).
+    func testWildcardAndMatchNotMigrated() {
+        XCTAssertNil(migrate("Host *\n  IdentityFile ~/.ssh/id\n"))
+        XCTAssertNil(HostSetup.migratedConfig("Match host web\n  IdentityFile ~/.ssh/id\n",
+                                              alias: "web", fobPubPath: pub, socketPath: sock))
+    }
+
+    // Missing alias entirely → nil.
+    func testMissingAliasReturnsNil() {
+        XCTAssertNil(migrate("Host other\n  HostName other.example\n"))
+    }
+
+    // MARK: - listHostBlocks
+
+    func testListHostBlocksSkipsWildcardAndMarksFob() {
+        let config = """
+        Host *
+          ForwardAgent no
+
+        Host web
+          HostName web.example
+          IdentityFile ~/.ssh/id
+
+        Host prod
+          HostName prod.example
+          IdentityAgent \(sock)
+        """
+        let blocks = HostSetup.listHostBlocks(in: config)
+        XCTAssertEqual(blocks.map(\.alias), ["web", "prod"])
+        XCTAssertFalse(blocks[0].usesFob)
+        XCTAssertTrue(blocks[1].usesFob)
+    }
+
+    // MARK: - installArguments (injection safety)
+
+    func testInstallArgumentsRejectsUnsafeAlias() {
+        XCTAssertNil(HostSetup.installArguments(alias: "-oProxyCommand=evil"))
+        XCTAssertNil(HostSetup.installArguments(alias: "has space"))
+    }
+
+    func testInstallArgumentsShape() {
+        let args = HostSetup.installArguments(alias: "web")!
+        XCTAssertEqual(args.last, HostSetup.remoteAppendScript)
+        XCTAssertTrue(args.contains("BatchMode=yes"))
+        XCTAssertTrue(args.contains("StrictHostKeyChecking=accept-new"))
+        XCTAssertEqual(args[args.count - 2], "web")
+    }
+
+    func testFallbackCommandPort() {
+        XCTAssertEqual(HostSetup.fallbackCopyCommand(alias: "web", fobPubPath: pub, port: 22),
+                       "ssh-copy-id -f -i \(pub) web")
+        XCTAssertTrue(HostSetup.fallbackCopyCommand(alias: "web", fobPubPath: pub, port: 2222)
+            .contains("-p 2222"))
+    }
+
+    // MARK: - installFailureHint
+
+    func testHintPermissionDeniedMentionsPassphrase() {
+        let hint = HostSetup.installFailureHint("oliv@192.168.64.64: Permission denied (publickey,password).")
+        XCTAssertTrue(hint.lowercased().contains("passphrase"))
+    }
+
+    func testHintUnreachable() {
+        XCTAssertTrue(HostSetup.installFailureHint("ssh: connect to host x port 22: Operation timed out")
+            .lowercased().contains("reach"))
+    }
+
+    // MARK: - sanitizeForDisplay
+
+    func testSanitizeStripsControlChars() {
+        let dirty = "Permission denied\u{1b}[0m\u{7f}\u{00}\nnext line"
+        let clean = HostSetup.sanitizeForDisplay(dirty)
+        XCTAssertFalse(clean.unicodeScalars.contains { $0.value == 0x1b || $0.value == 0x7f || $0.value == 0 })
+        XCTAssertTrue(clean.contains("Permission denied"))
+        XCTAssertTrue(clean.contains("next line"))
+    }
+
+    func testSanitizeCapsLinesAndLength() {
+        let many = (1...20).map { "line \($0)" }.joined(separator: "\n")
+        let clean = HostSetup.sanitizeForDisplay(many, maxLines: 3)
+        XCTAssertEqual(clean.split(separator: "\n").count, 3)
+        XCTAssertTrue(clean.contains("line 20"))
+        XCTAssertFalse(clean.contains("line 1\n"))
+    }
+
+    // MARK: - backupName
+
+    func testBackupNameFormat() {
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 7; comps.day = 11
+        comps.hour = 9; comps.minute = 45; comps.second = 12
+        let date = Calendar.current.date(from: comps)!
+        XCTAssertEqual(HostSetup.backupName(now: date), "config.fob-backup-20260711-094512")
+    }
+
+    // MARK: - GitConfig
+
+    func testGitConfigParse() {
+        let gc = """
+        [user]
+            name = Me
+            email = me@example.com
+            signingkey = /Users/me/.ssh/fob_signing.pub
+        [gpg]
+            format = ssh
+        """
+        let info = GitConfig.parse(gc)
+        XCTAssertEqual(info.format, "ssh")
+        XCTAssertEqual(info.signingKey, "/Users/me/.ssh/fob_signing.pub")
+        XCTAssertTrue(info.usesFob)
+    }
+
+    func testGitConfigNonFobSigningKey() {
+        let info = GitConfig.parse("[user]\n  signingkey = ~/.ssh/id_ed25519.pub\n[gpg]\n  format = ssh\n")
+        XCTAssertFalse(info.usesFob)
+        XCTAssertEqual(info.signingKey, "~/.ssh/id_ed25519.pub")
+    }
+
+    func testGitConfigEmpty() {
+        let info = GitConfig.parse("[core]\n  editor = vim\n")
+        XCTAssertNil(info.format)
+        XCTAssertNil(info.signingKey)
+        XCTAssertFalse(info.usesFob)
+    }
+
+    // MARK: - TextDiff
+
+    func testTextDiffAddedLines() {
+        let old = "a\nb\nc"
+        let new = "a\nX\nb\nc"
+        let diff = TextDiff.lines(old: old, new: new)
+        XCTAssertEqual(diff, [
+            .init(.same, "a"),
+            .init(.added, "X"),
+            .init(.same, "b"),
+            .init(.same, "c"),
+        ])
+    }
+
+    func testTextDiffRemovedLine() {
+        let diff = TextDiff.lines(old: "a\nb\nc", new: "a\nc")
+        XCTAssertEqual(diff, [.init(.same, "a"), .init(.removed, "b"), .init(.same, "c")])
+    }
+}


### PR DESCRIPTION
Make it easy — and safe — to move an existing SSH server onto fob. fob can't import a key (the Secure Enclave only generates on-device), so migration adds a new fob key ALONGSIDE the old one, proves it works, and retires the old one only when the user chooses. No cutover, no lockout.

FobKit (pure, tested):
- HostSetup.listHostBlocks — enumerate literal Host blocks (skip Match/wildcard)
- HostSetup.migratedConfig — rewrite a Host block to route through fob, inserting fob's IdentityAgent/IdentityFile BEFORE the old IdentityFile so fob is preferred and the old key is a fallback; idempotent; leaves other blocks untouched. Retire (comment out the old key) is a separate, opt-in step.
- installArguments/remoteAppendScript/fallbackCopyCommand (with -f, required since fob keys have no private file on disk), backupAndWriteConfig, installFailureHint (plain-language reason from the ssh error), sanitizeForDisplay, GitConfig, TextDiff
- 61 tests incl. 13 config-rewrite golden cases + ordering/injection/hint/sanitize

App:
- "Migrate to fob" window (lists ~/.ssh/config servers) + staged per-host flow: install via existing key → config diff preview → back up & apply → Verify (Touch ID) → pin → optional retire. Re-entry: a migrated host with an old key still shows "Retire old key…" so retire isn't a one-shot you can miss.
- Failed headless install surfaces a sanitized "Why it failed" + a plain-language hint (e.g. passphrase-locked key) and a Terminal fallback.
- First-run welcome card → Migrate; a "Migrate a server…" panel link; Generate now shows a copyable public key + next step.

CLI:
- `fob adopt` now performs the migration (install → backup+rewrite → verify → pin), with --dry-run (preview) and --retire; shared FobKit core with the app.
- `fob delete <name> [--force]` to erase a key (confirms by default).

README: migration section, feature bullet, CLI-reference rows.

Verified end-to-end against a real host: Touch ID prompt on connect, old key retained as fallback until retired.