### PR TITLE
Gitconfig-aware commit signing (multi-account includeIf support)

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -545,6 +545,32 @@ final class AppState: ObservableObject {
 
     // MARK: - Commit signing (the "Commit signing" window)
 
+    /// A git identity fob can write signing config into: a `~/.gitconfig` include
+    /// (from an `includeIf` block — the multi-account case), the global config, or the
+    /// current repo (copy-only — the window has no repo context).
+    enum SigningScope: Hashable {
+        case repository            // git config --local (shown as commands to run in the repo)
+        case identity(GitIdentity) // git config --file <include path>
+        case global                // git config --global
+
+        /// git-config location flag(s) — the args between `git config` and the key/value.
+        var flag: [String] {
+            switch self {
+            case .repository: return ["--local"]
+            case .identity(let id): return ["--file", id.path]
+            case .global: return ["--global"]
+            }
+        }
+    }
+
+    /// A per-identity include discovered in `~/.gitconfig` (via an `includeIf` block).
+    struct GitIdentity: Identifiable, Hashable {
+        let path: String            // expanded absolute path to the include file
+        let conditionLabel: String  // e.g. "gitdir:~/src/perso/"
+        let email: String?          // that file's user.email, for a friendly label
+        var id: String { path }
+    }
+
     struct SigningInfo {
         let name: String
         let pubLine: String            // add to the git host as a Signing Key
@@ -552,18 +578,17 @@ final class AppState: ObservableObject {
         let signerProgram: String      // ~/.fob/bin/fob-sign (git's gpg.ssh.program)
         let gitOnly: Bool              // policy currently restricts signing to "git"
 
-        /// The git config commands for a scope ("--global" or "--local"). The view
-        /// builds these so it can switch scope without re-reading the key. Uses a
-        /// `gpg.ssh.program` wrapper so only git signing reaches fob — SSH_AUTH_SOCK
-        /// (and any other ssh agent the user runs) is left completely alone.
-        func gitConfigCommands(global: Bool) -> [String] {
-            let scope = global ? "--global" : "--local"
+        /// The git config commands for a scope. The view builds these so it can switch
+        /// scope without re-reading the key. Uses a `gpg.ssh.program` wrapper so only git
+        /// signing reaches fob — SSH_AUTH_SOCK (and any other ssh agent) is left alone.
+        func gitConfigCommands(scope: SigningScope) -> [String] {
+            let flag = scope.flag.joined(separator: " ")
             return [
-                "git config \(scope) gpg.format ssh",
-                "git config \(scope) user.signingkey \(pubPath)",
-                "git config \(scope) gpg.ssh.program \(signerProgram)",
-                "git config \(scope) commit.gpgsign true",
-                "git config \(scope) tag.gpgsign true",
+                "git config \(flag) gpg.format ssh",
+                "git config \(flag) user.signingkey \(pubPath)",
+                "git config \(flag) gpg.ssh.program \(signerProgram)",
+                "git config \(flag) commit.gpgsign true",
+                "git config \(flag) tag.gpgsign true",
             ]
         }
     }
@@ -597,13 +622,17 @@ final class AppState: ObservableObject {
         }
     }
 
-    /// Run the `git config --global` signing setup for the user. nil = success.
-    func configureGitSigning(pubPath: String, signerProgram: String) -> String? {
-        for args in [["config", "--global", "gpg.format", "ssh"],
-                     ["config", "--global", "user.signingkey", pubPath],
-                     ["config", "--global", "gpg.ssh.program", signerProgram],
-                     ["config", "--global", "commit.gpgsign", "true"],
-                     ["config", "--global", "tag.gpgsign", "true"]] {
+    /// Write the signing config to `scope` (global, or a specific include file for a
+    /// multi-account identity). nil = success. `.repository` is not applied here — the
+    /// window has no repo context, so those are shown as copy commands.
+    func configureGitSigning(pubPath: String, signerProgram: String, scope: SigningScope) -> String? {
+        let settings = [["gpg.format", "ssh"],
+                        ["user.signingkey", pubPath],
+                        ["gpg.ssh.program", signerProgram],
+                        ["commit.gpgsign", "true"],
+                        ["tag.gpgsign", "true"]]
+        for kv in settings {
+            let args = ["config"] + scope.flag + kv
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
             process.arguments = args
@@ -615,6 +644,49 @@ final class AppState: ObservableObject {
             }
         }
         return nil
+    }
+
+    /// Whether `scope` already signs with this key (so the window can say "already set"
+    /// instead of implying action). True when its user.signingkey is this pubkey and
+    /// commit.gpgsign is on.
+    func signingConfigured(pubPath: String, scope: SigningScope) -> Bool {
+        let key = runGitSync(["config"] + scope.flag + ["user.signingkey"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let sign = runGitSync(["config"] + scope.flag + ["commit.gpgsign"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return key == pubPath && sign == "true"
+    }
+
+    /// The per-identity `includeIf` files in ~/.gitconfig, so the signing window can offer
+    /// each git identity as a target instead of only clobbering `--global`.
+    func discoverGitIdentities() -> [GitIdentity] {
+        let output = runGitSync(["config", "--global", "--get-regexp", "^includeif\\."])
+        return GitConfig.parseIncludeEntries(output).map { entry in
+            let path = (entry.path as NSString).expandingTildeInPath
+            let email = runGitSync(["config", "--file", path, "user.email"])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return GitIdentity(path: path, conditionLabel: entry.condition,
+                               email: email.isEmpty ? nil : email)
+        }
+    }
+
+    /// Run git synchronously and return stdout (empty on failure). Only used for fast,
+    /// local `git config` reads from the main actor.
+    private func runGitSync(_ args: [String]) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+            return String(decoding: data, as: UTF8.self)
+        } catch {
+            return ""
+        }
     }
 
     func unpin(name: String) {

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -14,14 +14,14 @@ struct SigningSetupView: View {
     @EnvironmentObject var state: AppState
     @Environment(\.dismiss) private var dismiss
 
-    private enum Scope { case repository, global }
-
     @State private var info: AppState.SigningInfo?
     @State private var gitOnly = false
-    @State private var scope: Scope = .repository
+    @State private var identities: [AppState.GitIdentity] = []
+    @State private var scope: AppState.SigningScope = .repository
     @State private var copied: String?
     @State private var gitConfigured = false
     @State private var gitError: String?
+    @State private var alreadyConfigured = false
 
     private var keyName: String { state.signingSetupKey ?? "" }
 
@@ -42,7 +42,17 @@ struct SigningSetupView: View {
     private func load() {
         info = state.signingInfo(for: keyName)
         gitOnly = info?.gitOnly ?? false
+        identities = state.discoverGitIdentities()
+        // Multi-account: default to the first identity (writing --global would clobber
+        // their setup). Single-account: default to per-repo (safe, universal).
+        scope = identities.first.map { .identity($0) } ?? .repository
         gitConfigured = false; gitError = nil; copied = nil
+        refreshConfigured()
+    }
+
+    /// Is the selected scope already signing with this key? (Answers "is it already set?")
+    private func refreshConfigured() {
+        alreadyConfigured = info.map { state.signingConfigured(pubPath: $0.pubPath, scope: scope) } ?? false
     }
 
     @ViewBuilder
@@ -64,32 +74,39 @@ struct SigningSetupView: View {
         }
 
         step(2, "Configure git to sign with this key", nil)
-        Picker("Scope", selection: $scope) {
-            Text("This repo").tag(Scope.repository)
-            Text("All repos (global)").tag(Scope.global)
+        Picker("Where", selection: $scope) {
+            ForEach(identities) { id in
+                Text(identityLabel(id)).tag(AppState.SigningScope.identity(id))
+            }
+            Text("This repo only").tag(AppState.SigningScope.repository)
+            Text(identities.isEmpty ? "All repos (global)" : "All repos (global) ⚠︎")
+                .tag(AppState.SigningScope.global)
         }
-        .pickerStyle(.segmented).labelsHidden().frame(width: 260)
-        Text(scope == .repository
-             ? "Recommended if you switch between git identities — run these **inside** the repo you want to sign. Doesn't touch your other repos."
-             : "⚠️ Sets signing for **every** repo on this Mac. If you use multiple git accounts, use “This repo” instead.")
-            .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
-        copyBox(info.gitConfigCommands(global: scope == .global).joined(separator: "\n"), id: "git")
-        if scope == .global {
+        .pickerStyle(.menu).labelsHidden().frame(maxWidth: 320, alignment: .leading)
+        .onChange(of: scope) { _ in gitConfigured = false; gitError = nil; refreshConfigured() }
+        Text(.init(scopeCaption)).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        if alreadyConfigured && !gitConfigured {
+            Label("Already signing with this key here — nothing to do.", systemImage: "checkmark.seal.fill")
+                .font(.caption).foregroundStyle(.green)
+        }
+        copyBox(info.gitConfigCommands(scope: scope).joined(separator: "\n"), id: "git")
+        if scope == .repository {
+            Text("Copy and run these inside the repo (the app can't target a repo for you).")
+                .font(.caption).foregroundStyle(.tertiary)
+        } else {
             HStack(spacing: 10) {
-                Button(gitConfigured ? "Configured ✓" : "Configure git for me") {
-                    if let err = state.configureGitSigning(pubPath: info.pubPath, signerProgram: info.signerProgram) { gitError = err; gitConfigured = false }
-                    else { gitConfigured = true; gitError = nil }
+                Button(configureButtonTitle) {
+                    if let err = state.configureGitSigning(pubPath: info.pubPath, signerProgram: info.signerProgram, scope: scope) {
+                        gitError = err; gitConfigured = false
+                    } else { gitConfigured = true; gitError = nil }
                 }
                 .disabled(gitConfigured)
                 if let gitError {
                     Text(gitError).font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
                 } else if gitConfigured {
-                    Text("git config --global set").font(.caption).foregroundStyle(.green)
+                    Text("written ✓").font(.caption).foregroundStyle(.green)
                 }
             }
-        } else {
-            Text("Copy and run these in the repo (the app can't target a repo for you).")
-                .font(.caption).foregroundStyle(.tertiary)
         }
 
         Text("fob signs commits through a `gpg.ssh.program` wrapper, so it **won't** change `SSH_AUTH_SOCK` — your other ssh agents and `git push` auth are untouched.")
@@ -103,11 +120,34 @@ struct SigningSetupView: View {
         }
     }
 
+    private var configureButtonTitle: String {
+        if gitConfigured { return "Configured ✓" }
+        return alreadyConfigured ? "Re-apply" : "Configure git for me"
+    }
+
+    private func identityLabel(_ id: AppState.GitIdentity) -> String {
+        let who = id.email ?? id.conditionLabel
+        return "\(who) — \((id.path as NSString).abbreviatingWithTildeInPath)"
+    }
+
+    private var scopeCaption: String {
+        switch scope {
+        case .identity(let id):
+            return "Signs commits in \(id.conditionLabel) repos, via \((id.path as NSString).abbreviatingWithTildeInPath). Your other git identities are untouched."
+        case .repository:
+            return "Run these **inside** the repo you want to sign. Doesn't touch anything else."
+        case .global:
+            return identities.isEmpty
+                ? "Sets signing for every repo on this Mac."
+                : "⚠️ Every repo on this Mac — this overrides your per-identity setup and would sign other accounts with this key. Prefer an identity above."
+        }
+    }
+
     private func step(_ n: Int, _ title: String, _ detail: String?) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text("\(n). \(title)").font(.callout.weight(.semibold))
             if let detail {
-                Text(detail).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                Text(.init(detail)).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/Sources/FobKit/GitConfig.swift
+++ b/Sources/FobKit/GitConfig.swift
@@ -42,4 +42,36 @@ public enum GitConfig {
         let usesFob = key.contains("/fob_") || key.contains("/.fob/")
         return SigningInfo(format: format, signingKey: signingKey, usesFob: usesFob)
     }
+
+    /// A conditional include in `~/.gitconfig` — a per-identity config file selected by a
+    /// condition (e.g. `gitdir:~/src/perso/` → `~/.gitconfig-perso`). This is how people
+    /// keep multiple git identities apart, and where per-identity signing config belongs.
+    public struct IncludeEntry: Equatable {
+        public let condition: String  // e.g. "gitdir:~/src/perso/", "gitdir/i:~/work/"
+        public let path: String       // e.g. "~/.gitconfig-perso" (tilde not expanded)
+        public init(condition: String, path: String) {
+            self.condition = condition
+            self.path = path
+        }
+    }
+
+    /// Parse the output of `git config --global --get-regexp '^includeif\.'`. Each line is
+    /// `includeif.<condition>.path <path>` (git lowercases the section/key but preserves the
+    /// quoted condition's case). Returns one entry per include.
+    public static func parseIncludeEntries(_ regexpOutput: String) -> [IncludeEntry] {
+        var entries: [IncludeEntry] = []
+        for raw in regexpOutput.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(raw)
+            guard let space = line.firstIndex(of: " ") else { continue }
+            let key = String(line[..<space])
+            let path = String(line[line.index(after: space)...]).trimmingCharacters(in: .whitespaces)
+            let lower = key.lowercased()
+            guard lower.hasPrefix("includeif."), lower.hasSuffix(".path"), !path.isEmpty else { continue }
+            let start = key.index(key.startIndex, offsetBy: "includeif.".count)
+            let end = key.index(key.endIndex, offsetBy: -".path".count)
+            guard start < end else { continue }
+            entries.append(IncludeEntry(condition: String(key[start..<end]), path: path))
+        }
+        return entries
+    }
 }

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -100,6 +100,20 @@ func fail(_ message: String) -> Never {
     exit(1)
 }
 
+/// Raw output of `git config --global --get-regexp '^includeif\.'` ("" on failure).
+func gitIncludeRegexp() -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = ["config", "--global", "--get-regexp", "^includeif\\."]
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+    guard (try? process.run()) != nil else { return "" }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return String(decoding: data, as: UTF8.self)
+}
+
 let arguments = Array(CommandLine.arguments.dropFirst())
 
 do {
@@ -246,6 +260,20 @@ do {
         print("")
         print("   The gpg.ssh.program wrapper routes ONLY git signing to fob's agent, so")
         print("   SSH_AUTH_SOCK is untouched — other ssh agents and `git push` still work.")
+        let includes = GitConfig.parseIncludeEntries(gitIncludeRegexp())
+        if !includes.isEmpty {
+            print("")
+            print("   ⚠︎ You have multiple git identities (includeIf) — do NOT use --global; it")
+            print("   would sign every account with this key. Write into the matching identity:")
+            for inc in includes {
+                let path = (inc.path as NSString).expandingTildeInPath
+                print("     # \(inc.condition)")
+                print("     git config --file \(path) gpg.format ssh")
+                print("     git config --file \(path) user.signingkey \(pubURL.path)")
+                print("     git config --file \(path) gpg.ssh.program \(signer)")
+                print("     git config --file \(path) commit.gpgsign true")
+            }
+        }
         print("")
         print("2. Register the key on your git host as a SIGNING key (a separate entry from")
         print("   an Authentication key) — e.g. GitHub or GitLab → Settings → SSH keys:")

--- a/Tests/FobKitTests/MigrationTests.swift
+++ b/Tests/FobKitTests/MigrationTests.swift
@@ -329,6 +329,27 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(info.signingKey, "~/.ssh/id_ed25519.pub")
     }
 
+    func testParseIncludeEntries() {
+        let out = """
+        includeif.gitdir:~/src/perso/.path ~/.gitconfig-perso
+        includeif.gitdir/i:~/Work/.path /Users/me/.gitconfig-work
+        """
+        let entries = GitConfig.parseIncludeEntries(out)
+        XCTAssertEqual(entries, [
+            .init(condition: "gitdir:~/src/perso/", path: "~/.gitconfig-perso"),
+            .init(condition: "gitdir/i:~/Work/", path: "/Users/me/.gitconfig-work"),
+        ])
+    }
+
+    func testParseIncludeEntriesEdgeCases() {
+        // A gitdir that itself contains ".path" must only lose the trailing ".path".
+        let entries = GitConfig.parseIncludeEntries("includeif.gitdir:~/x.path/.path ~/.gitconfig-x")
+        XCTAssertEqual(entries, [.init(condition: "gitdir:~/x.path/", path: "~/.gitconfig-x")])
+        // Non-include lines and empties are ignored.
+        XCTAssertTrue(GitConfig.parseIncludeEntries("").isEmpty)
+        XCTAssertTrue(GitConfig.parseIncludeEntries("user.email me@example.com").isEmpty)
+    }
+
     func testGitConfigEmpty() {
         let info = GitConfig.parse("[core]\n  editor = vim\n")
         XCTAssertNil(info.format)


### PR DESCRIPTION
fob's signing setup only wrote `git config --global`, which clobbers multi-account `includeIf` layouts (a main ~/.gitconfig that includes per-identity files by gitdir). Now the signing window detects those identities and writes to the right include file.

- FobKit: GitConfig.parseIncludeEntries parses `git config --get-regexp '^includeif\.'` into (condition, path); tested.
- AppState: SigningScope {repository, identity, global}; discoverGitIdentities (enumerate includes + read each file's user.email); configureGitSigning(scope:) writes via `git config --file <path>` / `--global`; signingConfigured() detects when a scope already signs with this key.
- SigningSetupView: scope picker lists each identity ("email — ~/.gitconfig-perso") and defaults to it; global is de-emphasized with a clobber warning when identities exist; "Already signing with this key here" state; "Re-apply" vs "Configure git for me"; fixed markdown that rendered literal ** (captions passed as variables now parse via Text(.init:)).
- CLI: `fob sign-setup` prints the includeIf identities + `git config --file …` commands and warns against --global when multiple identities exist.

Single-account users see no change. 69 FobKit tests. Verified on a real multi-account machine: the window offers  — ~/.gitconfig-perso" and writes there.