### PR TITLE
Add SSH checkup — read-only ~/.ssh hygiene report

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -514,6 +514,100 @@ final class AppState: ObservableObject {
         }
     }
 
+    // MARK: - SSH checkup (read-only hygiene report)
+
+    struct CheckupReport {
+        let findings: [SSHCheckup.Finding]
+        var high: Int { findings.filter { $0.severity == .high }.count }
+        var medium: Int { findings.filter { $0.severity == .medium }.count }
+        var low: Int { findings.filter { $0.severity == .low }.count }
+        var opportunities: Int { findings.filter { $0.severity == .opportunity }.count }
+        var isClean: Bool { findings.allSatisfy { $0.severity == .opportunity } }
+    }
+
+    /// Scan ~/.ssh read-only and return findings, most severe first. Reads private-key
+    /// files (encryption, permissions, type/bits), lints ~/.ssh/config, and surfaces
+    /// migrate/signing opportunities from the existing discovery. Never writes anything.
+    func runCheckup() async -> CheckupReport {
+        var findings: [SSHCheckup.Finding] = []
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+        let fm = FileManager.default
+
+        // 1. On-disk private keys.
+        let skipExact: Set<String> = ["config", "known_hosts", "authorized_keys", "agent.sock"]
+        let entries = (try? fm.contentsOfDirectory(atPath: sshDir.path)) ?? []
+        for name in entries.sorted() {
+            if name.hasSuffix(".pub") || name.hasPrefix("config.") || name.hasPrefix("known_hosts")
+                || skipExact.contains(name) || name.hasPrefix(".") { continue }
+            let url = sshDir.appendingPathComponent(name)
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDir), !isDir.boolValue,
+                  let contents = try? String(contentsOf: url, encoding: .utf8),
+                  let info = SSHCheckup.parsePrivateKey(contents) else { continue }
+
+            if !info.isEncrypted {
+                findings.append(.init(severity: .high, category: "Key",
+                    title: "“\(name)” has no passphrase",
+                    detail: "This private key is stored unencrypted — anyone who reads the file (a backup, a stolen laptop, malware running as you) gets a working key. Add a passphrase, or move the hosts that use it to a fob key (Secure Enclave keys can't be copied off the machine).",
+                    fix: .command("ssh-keygen -p -f \(url.path)")))
+            }
+            if let mode = (try? fm.attributesOfItem(atPath: url.path))?[.posixPermissions] as? Int,
+               SSHCheckup.isPrivateKeyPermissive(mode: mode) {
+                findings.append(.init(severity: .high, category: "Key",
+                    title: "“\(name)” is readable by other accounts",
+                    detail: "Mode \(String(mode, radix: 8)) — private keys must be owner-only. ssh will often refuse it too.",
+                    fix: .command("chmod 600 \(url.path)")))
+            }
+            if let (type, bits) = await sshKeyTypeBits(url), isWeakKey(type: type, bits: bits) {
+                findings.append(.init(severity: .medium, category: "Key",
+                    title: "“\(name)” is a weak/deprecated key (\(type)\(bits.map { " \($0)" } ?? ""))",
+                    detail: "Prefer Ed25519 (or a fob Secure Enclave key). DSA is disabled by modern OpenSSH; RSA under 3072 bits is weak.",
+                    fix: .none))
+            }
+        }
+
+        // 2. Risky ~/.ssh/config directives.
+        let config = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
+        findings += SSHCheckup.scanConfig(config)
+
+        // 3. Opportunities — hosts/signing not yet on fob (reuse existing discovery).
+        for c in discoverServers() where !c.usesFob {
+            let kind = c.isGitHost ? "git host" : "server"
+            findings.append(.init(severity: .opportunity, category: "Opportunity",
+                title: "“\(c.alias)” still uses an on-disk key",
+                detail: "This \(kind) authenticates with a plain key. Migrate it to a Touch ID-gated fob key.",
+                fix: .migrate(alias: c.alias)))
+        }
+        let signing = gitSigningInfo()
+        if (signing.signingKey != nil || signing.format != nil), !signing.usesFob {
+            findings.append(.init(severity: .opportunity, category: "Opportunity",
+                title: "Commit signing uses a non-fob key",
+                detail: "Your git signing key isn't a fob key. Move it so commit signatures are Touch ID-gated.",
+                fix: .signing))
+        }
+
+        return CheckupReport(findings: findings.sorted { $0.severity < $1.severity })
+    }
+
+    /// `(type, bits)` from `ssh-keygen -l -f <key>` — reads the public half, no passphrase.
+    private func sshKeyTypeBits(_ url: URL) async -> (type: String, bits: Int?)? {
+        let (status, out) = await runProcess("/usr/bin/ssh-keygen", ["-l", "-f", url.path])
+        guard status == 0 else { return nil }
+        // "256 SHA256:… comment (ED25519)"
+        let bits = out.split(separator: " ").first.flatMap { Int($0) }
+        guard let open = out.lastIndex(of: "("), let close = out.lastIndex(of: ")"), open < close else {
+            return nil
+        }
+        return (String(out[out.index(after: open)..<close]), bits)
+    }
+
+    private func isWeakKey(type: String, bits: Int?) -> Bool {
+        let t = type.uppercased()
+        if t.contains("DSA") { return true }               // ssh-dss / DSA — deprecated
+        if t.contains("RSA"), let bits, bits < 3072 { return true }
+        return false
+    }
+
     /// Run a subprocess off the main actor, feeding `stdin` if given, capturing merged
     /// stdout+stderr. `/usr/bin/ssh` bounds itself via BatchMode + ConnectTimeout.
     private func runProcess(_ launchPath: String, _ args: [String], stdin: String? = nil) async -> (status: Int32, output: String) {

--- a/Sources/FobApp/CheckupView.swift
+++ b/Sources/FobApp/CheckupView.swift
@@ -1,0 +1,144 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The "SSH checkup" window: a read-only scan of ~/.ssh (keys, config) plus
+/// migrate/signing opportunities, shown as severity-ranked findings. Every fix is opt-in
+/// — it either opens an existing fob flow or copies a command; the checkup never edits
+/// anything itself.
+struct CheckupView: View {
+    static let windowID = "fob-checkup"
+
+    @EnvironmentObject var state: AppState
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
+
+    @State private var report: AppState.CheckupReport?
+    @State private var running = false
+    @State private var copied: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("SSH checkup").font(.title2.weight(.semibold))
+                Spacer()
+                Button(running ? "Scanning…" : "Re-run") { run() }.disabled(running)
+            }
+            Text("A read-only look at your `~/.ssh` — keys, config, and what could move to fob. fob doesn't change anything here.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+
+            if let report {
+                summary(report)
+                if report.findings.isEmpty {
+                    Label("No issues found — your SSH setup looks healthy.", systemImage: "checkmark.seal.fill")
+                        .font(.callout).foregroundStyle(.green).padding(.vertical, 6)
+                } else {
+                    ScrollView {
+                        VStack(spacing: 8) {
+                            ForEach(report.findings) { finding in row(finding) }
+                        }
+                    }
+                    .frame(minHeight: 240, maxHeight: 480)
+                }
+            } else {
+                HStack { Spacer(); ProgressView(); Spacer() }.padding(.vertical, 20)
+            }
+
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(22)
+        .frame(width: 560)
+        .onAppear { if report == nil { run() } }
+    }
+
+    private func run() {
+        running = true
+        Task {
+            let r = await state.runCheckup()
+            report = r
+            running = false
+        }
+    }
+
+    private func summary(_ r: AppState.CheckupReport) -> some View {
+        HStack(spacing: 8) {
+            if r.high > 0 { pill("\(r.high) high", Theme.red) }
+            if r.medium > 0 { pill("\(r.medium) medium", .orange) }
+            if r.low > 0 { pill("\(r.low) low", .secondary) }
+            if r.opportunities > 0 { pill("\(r.opportunities) to improve", Theme.accent) }
+            if r.findings.isEmpty { pill("all clear", Theme.green) }
+        }
+    }
+
+    private func pill(_ text: String, _ color: Color) -> some View {
+        Text(text).font(.system(size: 11, weight: .semibold))
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(RoundedRectangle(cornerRadius: 6).fill(color.opacity(0.16)))
+            .foregroundStyle(color)
+    }
+
+    private func row(_ f: SSHCheckup.Finding) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(f.severity.label)
+                .font(.system(size: 9, weight: .bold)).tracking(0.4)
+                .padding(.horizontal, 5).padding(.vertical, 2)
+                .background(RoundedRectangle(cornerRadius: 4).fill(color(f.severity).opacity(0.16)))
+                .foregroundStyle(color(f.severity))
+                .frame(width: 58, alignment: .leading)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(f.title).font(.callout.weight(.semibold)).fixedSize(horizontal: false, vertical: true)
+                Text(f.detail).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                action(f)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+    }
+
+    @ViewBuilder
+    private func action(_ f: SSHCheckup.Finding) -> some View {
+        switch f.fix {
+        case .migrate(let alias):
+            Button("Migrate \(alias)…") {
+                state.migrateAlias = alias
+                NSApp.activate(ignoringOtherApps: true)
+                openWindow(id: MigrateHostView.windowID)
+            }.font(.caption).padding(.top, 2)
+        case .signing:
+            Text("Fix: a key's ••• → “Use for commit signing…”.")
+                .font(.caption).foregroundStyle(.tertiary)
+        case .command(let cmd):
+            HStack(spacing: 8) {
+                Text(cmd).font(.system(.caption2, design: .monospaced)).textSelection(.enabled)
+                    .padding(6).background(RoundedRectangle(cornerRadius: 5).fill(Color.secondary.opacity(0.12)))
+                Button(copied == cmd ? "Copied" : "Copy") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(cmd, forType: .string)
+                    copied = cmd
+                }.font(.caption)
+            }.padding(.top, 2)
+        case .revealFile(let path):
+            Button("Reveal in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+            }.font(.caption).padding(.top, 2)
+        case .none:
+            EmptyView()
+        }
+    }
+
+    private func color(_ s: SSHCheckup.Severity) -> Color {
+        switch s {
+        case .high: return Theme.red
+        case .medium: return .orange
+        case .low: return .secondary
+        case .opportunity: return Theme.accent
+        case .ok: return Theme.green
+        }
+    }
+}

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -344,6 +344,10 @@ struct ContentView: View {
             .padding(.horizontal, 14).padding(.vertical, 11)
             divider
             HStack {
+                footerButton("SSH checkup") {
+                    NSApp.activate(ignoringOtherApps: true)
+                    openWindow(id: CheckupView.windowID)
+                }
                 footerButton("Reveal audit log") { state.revealAuditLog() }
                 Spacer()
                 footerButton("Quit fob") { NSApplication.shared.terminate(nil) }

--- a/Sources/FobApp/FobApp.swift
+++ b/Sources/FobApp/FobApp.swift
@@ -32,6 +32,11 @@ struct FobApp: App {
             MigrateHostView().environmentObject(state)
         }
         .windowResizability(.contentSize)
+
+        Window("SSH checkup", id: CheckupView.windowID) {
+            CheckupView().environmentObject(state)
+        }
+        .windowResizability(.contentMinSize)
     }
 }
 

--- a/Sources/FobKit/SSHCheckup.swift
+++ b/Sources/FobKit/SSHCheckup.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Read-only SSH hygiene checks. The pure detection lives here (encryption detection,
+/// risky-directive scanning, permission rules) so it's testable; file enumeration and
+/// subprocess calls (`ssh-keygen -l`, stat) live in the app/CLI layer that builds the
+/// full report. Nothing here writes anything.
+public enum SSHCheckup {
+    public enum Severity: Int, Comparable {
+        case high = 0, medium = 1, low = 2, opportunity = 3, ok = 4
+        public static func < (a: Severity, b: Severity) -> Bool { a.rawValue < b.rawValue }
+        public var label: String {
+            switch self {
+            case .high: return "HIGH"
+            case .medium: return "MEDIUM"
+            case .low: return "LOW"
+            case .opportunity: return "IMPROVE"
+            case .ok: return "OK"
+            }
+        }
+    }
+
+    /// What the UI/CLI can offer for a finding (all opt-in; the checkup never acts itself).
+    public enum FixHint: Equatable {
+        case migrate(alias: String) // open the Migrate flow for this host
+        case signing               // open the commit-signing flow
+        case command(String)       // copy-paste guidance (a config line / chmod)
+        case revealFile(String)    // reveal a key file in Finder
+        case none
+    }
+
+    public struct Finding: Equatable, Identifiable {
+        public let severity: Severity
+        public let category: String   // "Key" · "Config" · "Opportunity"
+        public let title: String
+        public let detail: String
+        public let fix: FixHint
+        public var id: String { "\(category)|\(title)" }
+        public init(severity: Severity, category: String, title: String, detail: String, fix: FixHint) {
+            self.severity = severity
+            self.category = category
+            self.title = title
+            self.detail = detail
+            self.fix = fix
+        }
+    }
+
+    // MARK: - Private-key encryption detection
+
+    public struct PrivateKeyInfo: Equatable {
+        public let isEncrypted: Bool
+        public init(isEncrypted: Bool) { self.isEncrypted = isEncrypted }
+    }
+
+    /// Determine whether a private-key file is passphrase-encrypted. Returns nil if the
+    /// contents aren't a private key at all. When the format is a private key but can't be
+    /// parsed, errs on the side of `isEncrypted: true` (no false "unencrypted!" alarm).
+    public static func parsePrivateKey(_ contents: String) -> PrivateKeyInfo? {
+        if contents.contains("BEGIN OPENSSH PRIVATE KEY") {
+            guard let b64 = base64Body(contents,
+                                       begin: "-----BEGIN OPENSSH PRIVATE KEY-----",
+                                       end: "-----END OPENSSH PRIVATE KEY-----"),
+                  let data = Data(base64Encoded: b64) else {
+                return PrivateKeyInfo(isEncrypted: true)
+            }
+            // Layout: "openssh-key-v1\0" magic, then uint32 len + ciphername. "none" == plain.
+            let bytes = [UInt8](data)
+            let magic = [UInt8]("openssh-key-v1\u{0}".utf8) // 15 bytes
+            let i = magic.count
+            guard bytes.count > i + 4, Array(bytes.prefix(i)) == magic else {
+                return PrivateKeyInfo(isEncrypted: true)
+            }
+            let len = Int(bytes[i]) << 24 | Int(bytes[i + 1]) << 16 | Int(bytes[i + 2]) << 8 | Int(bytes[i + 3])
+            guard len >= 0, bytes.count >= i + 4 + len else { return PrivateKeyInfo(isEncrypted: true) }
+            let cipher = String(decoding: bytes[(i + 4)..<(i + 4 + len)], as: UTF8.self)
+            return PrivateKeyInfo(isEncrypted: cipher != "none")
+        }
+        if contents.contains("PRIVATE KEY-----") {
+            // Legacy PEM / PKCS#8: encrypted markers are "ENCRYPTED" (PKCS#8) or
+            // "Proc-Type: 4,ENCRYPTED" / "DEK-Info:" (traditional).
+            let enc = contents.contains("ENCRYPTED") || contents.contains("DEK-Info:")
+            return PrivateKeyInfo(isEncrypted: enc)
+        }
+        return nil
+    }
+
+    private static func base64Body(_ contents: String, begin: String, end: String) -> String? {
+        guard let b = contents.range(of: begin), let e = contents.range(of: end),
+              b.upperBound <= e.lowerBound else { return nil }
+        return contents[b.upperBound..<e.lowerBound].split(whereSeparator: \.isNewline).joined()
+    }
+
+    // MARK: - File permissions
+
+    /// A private key readable by group or other (`mode & 0o077 != 0`) — ssh itself refuses
+    /// these, and it means another local account could read the key.
+    public static func isPrivateKeyPermissive(mode: Int) -> Bool { mode & 0o077 != 0 }
+
+    // MARK: - Risky ~/.ssh/config directives
+
+    /// Scan config text for dangerous directives, tracking which `Host`/`Match` block each
+    /// falls under (a global `Host *` amplifies the severity).
+    public static func scanConfig(_ text: String) -> [Finding] {
+        var findings: [Finding] = []
+        var scope = "(global)"
+        var wildcard = true   // directives before any Host apply everywhere
+        for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let lower = line.lowercased()
+            if lower == "host" || lower.hasPrefix("host ") {
+                let patterns = line.dropFirst(4).split(whereSeparator: { $0 == " " || $0 == "\t" }).map(String.init)
+                scope = "Host " + patterns.joined(separator: " ")
+                wildcard = patterns.contains("*")
+                continue
+            }
+            if lower == "match" || lower.hasPrefix("match ") {
+                scope = line; wildcard = true; continue
+            }
+            guard let sep = line.firstIndex(where: { $0 == " " || $0 == "\t" || $0 == "=" }) else { continue }
+            let key = line[..<sep].lowercased()
+            let value = line[line.index(after: sep)...].trimmingCharacters(in: CharacterSet(charactersIn: " \t=\"")).lowercased()
+            switch key {
+            case "stricthostkeychecking" where value == "no":
+                findings.append(.init(severity: .high, category: "Config",
+                    title: "StrictHostKeyChecking no · \(scope)",
+                    detail: "Accepts any host key without checking — no protection against a man-in-the-middle. Use “accept-new” or “ask”.",
+                    fix: .command("StrictHostKeyChecking accept-new")))
+            case "userknownhostsfile" where value.contains("/dev/null"):
+                findings.append(.init(severity: .high, category: "Config",
+                    title: "UserKnownHostsFile /dev/null · \(scope)",
+                    detail: "Throws away host-key memory, so a changed (possibly attacker) host key is never noticed.",
+                    fix: .none))
+            case "forwardagent" where value == "yes":
+                findings.append(.init(severity: wildcard ? .high : .medium, category: "Config",
+                    title: "ForwardAgent yes · \(scope)",
+                    detail: wildcard
+                        ? "Forwards your agent to EVERY host — a malicious or compromised server can use your keys. Scope it to specific trusted hosts, or drop it for ProxyJump."
+                        : "That host can use your loaded keys while you're connected. Prefer ProxyJump unless you fully trust it.",
+                    fix: .none))
+            case "identitiesonly" where value == "no":
+                findings.append(.init(severity: .low, category: "Config",
+                    title: "IdentitiesOnly no · \(scope)",
+                    detail: "Offers every loaded key to the host, revealing which keys you hold. Set “IdentitiesOnly yes” with an explicit IdentityFile.",
+                    fix: .command("IdentitiesOnly yes")))
+            default:
+                break
+            }
+        }
+        return findings
+    }
+}

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -34,6 +34,11 @@ USAGE:
       Permanently erase a key from the Secure Enclave (asks to confirm; --force
       skips). Remove its public key from any server/host that still trusts it.
 
+  fob checkup
+      Read-only SSH hygiene report: flags unencrypted / weak / loosely-permissioned
+      on-disk keys, risky ~/.ssh/config directives, and hosts/signing that could move
+      to fob. Changes nothing.
+
   fob pin <name> <host>
       Pin a key to a host: the agent will refuse to sign with this key for
       any other destination, or for clients that don't identify one. Host
@@ -100,6 +105,73 @@ func fail(_ message: String) -> Never {
     exit(1)
 }
 
+/// `(type, bits)` from `ssh-keygen -l -f <key>`, or nil.
+func sshKeygenTypeBits(_ path: String) -> (type: String, bits: Int?)? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh-keygen")
+    process.arguments = ["-l", "-f", path]
+    let pipe = Pipe(); process.standardOutput = pipe; process.standardError = Pipe()
+    guard (try? process.run()) != nil else { return nil }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else { return nil }
+    let out = String(decoding: data, as: UTF8.self)
+    let bits = out.split(separator: " ").first.flatMap { Int($0) }
+    guard let o = out.lastIndex(of: "("), let c = out.lastIndex(of: ")"), o < c else { return nil }
+    return (String(out[out.index(after: o)..<c]), bits)
+}
+
+/// Read-only SSH hygiene findings for `fob checkup` (keys + config + fob opportunities).
+func sshCheckupFindings() -> [SSHCheckup.Finding] {
+    var findings: [SSHCheckup.Finding] = []
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let sshDir = home.appendingPathComponent(".ssh")
+    let fm = FileManager.default
+
+    let skip: Set<String> = ["config", "known_hosts", "authorized_keys", "agent.sock"]
+    for name in ((try? fm.contentsOfDirectory(atPath: sshDir.path)) ?? []).sorted() {
+        if name.hasSuffix(".pub") || name.hasPrefix("config.") || name.hasPrefix("known_hosts")
+            || skip.contains(name) || name.hasPrefix(".") { continue }
+        let path = sshDir.appendingPathComponent(name).path
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8),
+              let info = SSHCheckup.parsePrivateKey(contents) else { continue }
+        if !info.isEncrypted {
+            findings.append(.init(severity: .high, category: "Key", title: "“\(name)” has no passphrase",
+                detail: "Stored unencrypted — a copy of the file is a working key. Add a passphrase (ssh-keygen -p -f \(path)) or move its hosts to fob.", fix: .none))
+        }
+        if let mode = (try? fm.attributesOfItem(atPath: path))?[.posixPermissions] as? Int,
+           SSHCheckup.isPrivateKeyPermissive(mode: mode) {
+            findings.append(.init(severity: .high, category: "Key", title: "“\(name)” is readable by other accounts",
+                detail: "Mode \(String(mode, radix: 8)). Fix: chmod 600 \(path)", fix: .none))
+        }
+        if let (type, bits) = sshKeygenTypeBits(path) {
+            let t = type.uppercased()
+            if t.contains("DSA") || (t.contains("RSA") && (bits ?? 4096) < 3072) {
+                findings.append(.init(severity: .medium, category: "Key",
+                    title: "“\(name)” is a weak/deprecated key (\(type)\(bits.map { " \($0)" } ?? ""))",
+                    detail: "Prefer Ed25519 or a fob Secure Enclave key.", fix: .none))
+            }
+        }
+    }
+
+    let config = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
+    findings += SSHCheckup.scanConfig(config)
+
+    for block in HostSetup.listHostBlocks(in: config) where !block.usesFob {
+        findings.append(.init(severity: .opportunity, category: "Opportunity",
+            title: "“\(block.alias)” still uses an on-disk key",
+            detail: "Migrate it to a fob key:  fob adopt \(block.alias)", fix: .none))
+    }
+    let gitconfig = (try? String(contentsOf: home.appendingPathComponent(".gitconfig"), encoding: .utf8)) ?? ""
+    let signing = GitConfig.parse(gitconfig)
+    if (signing.signingKey != nil || signing.format != nil), !signing.usesFob {
+        findings.append(.init(severity: .opportunity, category: "Opportunity",
+            title: "Commit signing uses a non-fob key",
+            detail: "Set up a fob signing key:  fob sign-setup <key>", fix: .none))
+    }
+    return findings.sorted { $0.severity < $1.severity }
+}
+
 /// Raw output of `git config --global --get-regexp '^includeif\.'` ("" on failure).
 func gitIncludeRegexp() -> String {
     let process = Process()
@@ -148,6 +220,24 @@ do {
         }
         for key in keys {
             print(SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(key.name)"))
+        }
+
+    case "checkup":
+        let findings = sshCheckupFindings()
+        if findings.isEmpty {
+            print("✅ SSH checkup: no issues found — your ~/.ssh looks healthy.")
+        } else {
+            let high = findings.filter { $0.severity == .high }.count
+            let med = findings.filter { $0.severity == .medium }.count
+            let low = findings.filter { $0.severity == .low }.count
+            let opp = findings.filter { $0.severity == .opportunity }.count
+            print("SSH checkup — \(high) high · \(med) medium · \(low) low · \(opp) to improve")
+            print("(read-only; fob changed nothing)")
+            for f in findings {
+                print("")
+                print("[\(f.severity.label)] \(f.title)")
+                print("  \(f.detail)")
+            }
         }
 
     case "delete":

--- a/Tests/FobKitTests/CheckupTests.swift
+++ b/Tests/FobKitTests/CheckupTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+
+@testable import FobKit
+
+final class CheckupTests: XCTestCase {
+    // MARK: - parsePrivateKey
+
+    func testUnencryptedOpenSSHKey() {
+        // A real unencrypted ed25519 OpenSSH key (cipher "none").
+        let key = """
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+        QyNTUxOQAAACBHUJVXfxRBGgZA5pBGADoQ0LZkfunGi73KqPuYYni2vAAAAKDv0aXt79Gl
+        7QAAAAtzc2gtZWQyNTUxOQAAACBHUJVXfxRBGgZA5pBGADoQ0LZkfunGi73KqPuYYni2v
+        AAAAEBnZ2h0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        -----END OPENSSH PRIVATE KEY-----
+        """
+        // The body above is illustrative; construct a valid one programmatically instead.
+        let real = Self.makeOpenSSHKey(cipher: "none")
+        XCTAssertEqual(SSHCheckup.parsePrivateKey(real)?.isEncrypted, false)
+        _ = key
+    }
+
+    func testEncryptedOpenSSHKey() {
+        let enc = Self.makeOpenSSHKey(cipher: "aes256-ctr")
+        XCTAssertEqual(SSHCheckup.parsePrivateKey(enc)?.isEncrypted, true)
+    }
+
+    func testLegacyPEMEncrypted() {
+        let pem = """
+        -----BEGIN RSA PRIVATE KEY-----
+        Proc-Type: 4,ENCRYPTED
+        DEK-Info: AES-128-CBC,0123456789ABCDEF
+
+        AAAA
+        -----END RSA PRIVATE KEY-----
+        """
+        XCTAssertEqual(SSHCheckup.parsePrivateKey(pem)?.isEncrypted, true)
+    }
+
+    func testLegacyPEMPlain() {
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----\n"
+        XCTAssertEqual(SSHCheckup.parsePrivateKey(pem)?.isEncrypted, false)
+    }
+
+    func testNotAPrivateKey() {
+        XCTAssertNil(SSHCheckup.parsePrivateKey("ssh-ed25519 AAAA... comment"))
+        XCTAssertNil(SSHCheckup.parsePrivateKey("just some text"))
+    }
+
+    /// Build a minimal valid OpenSSH-format private key blob with the given cipher name,
+    /// so encryption detection is tested against the real binary layout.
+    private static func makeOpenSSHKey(cipher: String) -> String {
+        var blob = [UInt8]("openssh-key-v1\u{0}".utf8)
+        let name = [UInt8](cipher.utf8)
+        blob += [UInt8((name.count >> 24) & 0xff), UInt8((name.count >> 16) & 0xff),
+                 UInt8((name.count >> 8) & 0xff), UInt8(name.count & 0xff)]
+        blob += name
+        blob += [0, 0, 0, 4, 110, 111, 110, 101] // a trailing field, ignored by the parser
+        let b64 = Data(blob).base64EncodedString()
+        return "-----BEGIN OPENSSH PRIVATE KEY-----\n\(b64)\n-----END OPENSSH PRIVATE KEY-----\n"
+    }
+
+    // MARK: - permissions
+
+    func testPermissive() {
+        XCTAssertFalse(SSHCheckup.isPrivateKeyPermissive(mode: 0o600))
+        XCTAssertFalse(SSHCheckup.isPrivateKeyPermissive(mode: 0o400))
+        XCTAssertTrue(SSHCheckup.isPrivateKeyPermissive(mode: 0o644))
+        XCTAssertTrue(SSHCheckup.isPrivateKeyPermissive(mode: 0o640))
+        XCTAssertTrue(SSHCheckup.isPrivateKeyPermissive(mode: 0o660))
+    }
+
+    // MARK: - scanConfig
+
+    func testScanFlagsRiskyDirectives() {
+        let config = """
+        Host prod
+          HostName prod.example
+          StrictHostKeyChecking no
+          ForwardAgent yes
+
+        Host *
+          ForwardAgent yes
+          IdentitiesOnly no
+        """
+        let f = SSHCheckup.scanConfig(config)
+        // StrictHostKeyChecking no under Host prod → high
+        XCTAssertTrue(f.contains { $0.title.contains("StrictHostKeyChecking no") && $0.severity == .high })
+        // ForwardAgent under a specific host = medium; under Host * = high
+        XCTAssertTrue(f.contains { $0.title.contains("ForwardAgent yes · Host prod") && $0.severity == .medium })
+        XCTAssertTrue(f.contains { $0.title.contains("ForwardAgent yes · Host *") && $0.severity == .high })
+        XCTAssertTrue(f.contains { $0.title.contains("IdentitiesOnly no") && $0.severity == .low })
+    }
+
+    func testCleanConfigNoFindings() {
+        let config = """
+        Host web
+          HostName web.example
+          User me
+          IdentityAgent ~/.fob/agent.sock
+          IdentitiesOnly yes
+          StrictHostKeyChecking accept-new
+        """
+        XCTAssertTrue(SSHCheckup.scanConfig(config).isEmpty)
+    }
+
+    func testUserKnownHostsDevNull() {
+        let f = SSHCheckup.scanConfig("Host x\n  UserKnownHostsFile /dev/null\n")
+        XCTAssertTrue(f.contains { $0.title.contains("/dev/null") && $0.severity == .high })
+    }
+}


### PR DESCRIPTION
SSH checkup — read-only ~/.ssh hygiene report. Flags unencrypted/weak/loose-perm on-disk keys, risky ~/.ssh/config directives, and hosts/signing that could move to fob. Read-only; fixes route into Migrate/commit-signing. New CheckupView window + footer entry + fob checkup CLI. 79 FobKit tests.