### PR TITLE
Unified "New key" flow + git-identity & allowed_signers checkup

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -34,6 +34,8 @@ final class AppState: ObservableObject {
     @Published var signingSetupHost: String?
     /// The alias the "Migrate a server" window is set up for (set before opening it).
     @Published var migrateAlias: String?
+    /// Bumped after any ~/.ssh/config write so open lists (e.g. Migrate) refresh live.
+    @Published var configRevision = 0
 
     private let store: KeyStore?
     private var agent: Agent?
@@ -96,8 +98,10 @@ final class AppState: ObservableObject {
         let all = (try? store.all()) ?? []
         keys = all.map { key in
             let policy = store.policy(name: key.name)
+            // Prefer the alias matching the key name so a key pinned to a shared HostName
+            // (github-ousson / github-feedly both → github.com) shows its own alias.
             let names = policy.pinnedHostKeys.map {
-                HostResolver.name(forHostKeyBlob: $0) ?? "unknown host key"
+                HostResolver.name(forHostKeyBlob: $0, preferredAlias: key.name) ?? "unknown host key"
             }
             return KeyInfo(name: key.name,
                            pinnedNames: Array(Set(names)).sorted(),
@@ -213,6 +217,7 @@ final class AppState: ObservableObject {
                 configAdded = true
             }
             refreshKeys()
+            if configAdded { configRevision += 1 }
             var copy = ["ssh-copy-id", "-f", "-i", pubURL.path]
             if port != 22 { copy += ["-p", String(port)] }
             copy.append("\(user)@\(host)")
@@ -377,6 +382,7 @@ final class AppState: ObservableObject {
         }
         do {
             let backup = try HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
+            configRevision += 1
             return .ok(backup: backup.lastPathComponent)
         } catch {
             return .error(error.localizedDescription)
@@ -436,6 +442,7 @@ final class AppState: ObservableObject {
                 try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: sshConfigURL.path)
             }
             refreshKeys()
+            configRevision += 1
             return nil
         } catch {
             return error.localizedDescription
@@ -508,6 +515,7 @@ final class AppState: ObservableObject {
         }
         do {
             let backup = try HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
+            configRevision += 1
             return .ok(backup: backup.lastPathComponent)
         } catch {
             return .error(error.localizedDescription)
@@ -546,10 +554,10 @@ final class AppState: ObservableObject {
                   let info = SSHCheckup.parsePrivateKey(contents) else { continue }
 
             if !info.isEncrypted {
-                findings.append(.init(severity: .high, category: "Key",
-                    title: "“\(name)” has no passphrase",
-                    detail: "This private key is stored unencrypted — anyone who reads the file (a backup, a stolen laptop, malware running as you) gets a working key. Add a passphrase, or move the hosts that use it to a fob key (Secure Enclave keys can't be copied off the machine).",
-                    fix: .command("ssh-keygen -p -f \(url.path)")))
+                let cfg = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+                let referenced = SSHCheckup.isKeyReferenced(
+                    keyPath: url.path, configText: cfg, gitSigningKey: gitSigningInfo().signingKey)
+                findings.append(SSHCheckup.unencryptedKeyFinding(name: name, path: url.path, referenced: referenced))
             }
             if let mode = (try? fm.attributesOfItem(atPath: url.path))?[.posixPermissions] as? Int,
                SSHCheckup.isPrivateKeyPermissive(mode: mode) {
@@ -570,6 +578,17 @@ final class AppState: ObservableObject {
         let config = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
         findings += SSHCheckup.scanConfig(config)
 
+        // 2b. Multi-account git-identity footgun.
+        let identities = discoverGitIdentities()
+        let useConfigOnly = runGitSync(["config", "--global", "user.useConfigOnly"])
+            .trimmingCharacters(in: .whitespacesAndNewlines) == "true"
+        let defaultEmail = runGitSync(["config", "--global", "user.email"])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let f = SSHCheckup.identityFinding(includeCount: identities.count,
+                                              useConfigOnly: useConfigOnly, defaultEmail: defaultEmail) {
+            findings.append(f)
+        }
+
         // 3. Opportunities — hosts/signing not yet on fob (reuse existing discovery).
         for c in discoverServers() where !c.usesFob {
             let kind = c.isGitHost ? "git host" : "server"
@@ -584,6 +603,22 @@ final class AppState: ObservableObject {
                 title: "Commit signing uses a non-fob key",
                 detail: "Your git signing key isn't a fob key. Move it so commit signatures are Touch ID-gated.",
                 fix: .signing))
+        }
+
+        // 3b. fob signing set up, but can it be verified locally?
+        if signing.usesFob {
+            let asFile = runGitSync(["config", "--global", "gpg.ssh.allowedSignersFile"])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            var keyListed = false
+            if !asFile.isEmpty, let sk = signing.signingKey {
+                let asText = (try? String(contentsOfFile: (asFile as NSString).expandingTildeInPath, encoding: .utf8)) ?? ""
+                let pub = (try? String(contentsOfFile: (sk as NSString).expandingTildeInPath, encoding: .utf8)) ?? ""
+                keyListed = SSHCheckup.AllowedSigners.contains(asText, pubLine: pub)
+            }
+            if let f = SSHCheckup.signingVerificationFinding(
+                usesFobSigning: true, allowedSignersConfigured: !asFile.isEmpty, keyListed: keyListed) {
+                findings.append(f)
+            }
         }
 
         return CheckupReport(findings: findings.sorted { $0.severity < $1.severity })
@@ -683,6 +718,7 @@ final class AppState: ObservableObject {
                 "git config \(flag) gpg.ssh.program \(signerProgram)",
                 "git config \(flag) commit.gpgsign true",
                 "git config \(flag) tag.gpgsign true",
+                "git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers",
             ]
         }
     }
@@ -719,14 +755,22 @@ final class AppState: ObservableObject {
     /// Write the signing config to `scope` (global, or a specific include file for a
     /// multi-account identity). nil = success. `.repository` is not applied here — the
     /// window has no repo context, so those are shown as copy commands.
-    func configureGitSigning(pubPath: String, signerProgram: String, scope: SigningScope) -> String? {
-        let settings = [["gpg.format", "ssh"],
-                        ["user.signingkey", pubPath],
-                        ["gpg.ssh.program", signerProgram],
-                        ["commit.gpgsign", "true"],
-                        ["tag.gpgsign", "true"]]
-        for kv in settings {
-            let args = ["config"] + scope.flag + kv
+    func configureGitSigning(pubPath: String, signerProgram: String, pubLine: String, scope: SigningScope) -> String? {
+        let signersPath = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ssh/allowed_signers").path
+        // Signing itself is scoped (so multi-account setups don't clobber each other);
+        // the allow-list pointer is a harmless shared path, set globally so verification
+        // works in every repo, not just this identity's directories.
+        let writes: [[String]] = [
+            scope.flag + ["gpg.format", "ssh"],
+            scope.flag + ["user.signingkey", pubPath],
+            scope.flag + ["gpg.ssh.program", signerProgram],
+            scope.flag + ["commit.gpgsign", "true"],
+            scope.flag + ["tag.gpgsign", "true"],
+            ["--global", "gpg.ssh.allowedSignersFile", signersPath],
+        ]
+        for kv in writes {
+            let args = ["config"] + kv
             let process = Process()
             process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
             process.arguments = args
@@ -737,7 +781,26 @@ final class AppState: ObservableObject {
                 return error.localizedDescription
             }
         }
+        // Add the key to allowed_signers so `git verify-commit` works locally.
+        if let email = signingEmail(for: scope) { addAllowedSigner(email: email, pubLine: pubLine) }
         return nil
+    }
+
+    /// The committer email a signature under `scope` will carry — the include identity's
+    /// email, else the global user.email.
+    private func signingEmail(for scope: SigningScope) -> String? {
+        if case .identity(let id) = scope, let e = id.email { return e }
+        let e = runGitSync(["config", "--global", "user.email"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return e.isEmpty ? nil : e
+    }
+
+    /// Append an entry to ~/.ssh/allowed_signers (idempotent) so signed commits verify locally.
+    private func addAllowedSigner(email: String, pubLine: String) {
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/allowed_signers")
+        let text = (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+        guard let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: pubLine) else { return }
+        try? Data(updated.utf8).write(to: url, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
     }
 
     /// Whether `scope` already signs with this key (so the window can say "already set"
@@ -825,12 +888,24 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// Map a `~/.ssh/config` alias (e.g. "github-ousson") to its real HostName + Port for
+    /// a known_hosts lookup. known_hosts is keyed by hostname (github.com), not the alias.
+    /// Returns the token unchanged if it isn't a config alias.
+    private func resolveKnownHost(_ token: String) -> (host: String, port: Int?) {
+        let config = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        if let parsed = HostSetup.parseHostBlock(alias: token, in: config), let hostName = parsed.hostName {
+            return (hostName, parsed.port)
+        }
+        return (token, nil)
+    }
+
     func pin(name: String, toHost host: String) {
+        let (resolved, port) = resolveKnownHost(host)
         run { store in
-            let hostKeys = HostResolver.knownHostKeys(for: host)
+            let hostKeys = HostResolver.knownHostKeys(for: resolved, port: port)
             guard !hostKeys.isEmpty else {
                 throw ActionError.message(
-                    "No host key for “\(host)” in ~/.ssh/known_hosts yet.\n\n"
+                    "No host key for “\(resolved)” in ~/.ssh/known_hosts yet.\n\n"
                     + "Pinning binds this key to the host’s public key, so the host "
                     + "must be known first. Connect to it once — e.g. `ssh \(host)` "
                     + "and accept the prompt — or run `fob setup \(host)`. Then pin again.")

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -56,8 +56,6 @@ struct ContentView: View {
     @Environment(\.colorScheme) private var scheme
     @Environment(\.openWindow) private var openWindow
 
-    @State private var newKeyName = ""
-    @State private var newKeyBiometry = true
     @State private var openMenuKey: String?
 
     private var t: Theme { Theme.current(scheme) }
@@ -157,7 +155,7 @@ struct ContentView: View {
                     .background(RoundedRectangle(cornerRadius: 7).fill(Theme.accent))
             }
             .buttonStyle(.plain)
-            Text("…or create your first key below.")
+            Text("…or **New key…** below to create one from scratch.")
                 .font(.system(size: 11)).foregroundStyle(t.sub)
         }
         .padding(.horizontal, 14).padding(.top, 2).padding(.bottom, 10)
@@ -187,61 +185,14 @@ struct ContentView: View {
         .padding(.horizontal, 14).padding(.vertical, 8)
     }
 
-    // MARK: New key
+    // MARK: New key / actions
 
     private var newKeySection: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            sectionLabel("NEW KEY").padding(.horizontal, 14).padding(.top, 12).padding(.bottom, 6)
-            HStack(spacing: 8) {
-                TextField("key name", text: $newKeyName)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 12.5)).foregroundStyle(t.text)
-                    .padding(.horizontal, 10).frame(height: 28)
-                    .background(RoundedRectangle(cornerRadius: 7).fill(t.fieldBg))
-                    .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(t.fieldBorder, lineWidth: 0.5))
-                    .onSubmit(generate)
-                Button(action: generate) {
-                    Text("Generate")
-                        .font(.system(size: 12.5, weight: .semibold)).foregroundStyle(.white)
-                        .padding(.horizontal, 14).frame(height: 28)
-                        .background(RoundedRectangle(cornerRadius: 7).fill(Theme.accent))
-                }
-                .buttonStyle(.plain)
-                .disabled(newKeyName.trimmingCharacters(in: .whitespaces).isEmpty)
-                .opacity(newKeyName.trimmingCharacters(in: .whitespaces).isEmpty ? 0.5 : 1)
-            }
-            .padding(.horizontal, 14)
-
-            Button { newKeyBiometry.toggle() } label: {
-                HStack(spacing: 7) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(newKeyBiometry ? Theme.accent : .clear)
-                        RoundedRectangle(cornerRadius: 4)
-                            .strokeBorder(newKeyBiometry ? Theme.accent : t.sub.opacity(0.5), lineWidth: 1.5)
-                        if newKeyBiometry {
-                            Image(systemName: "checkmark").font(.system(size: 8, weight: .bold)).foregroundStyle(.white)
-                        }
-                    }
-                    .frame(width: 15, height: 15)
-                    Text("Touch ID only").font(.system(size: 12)).foregroundStyle(t.text)
-                }
-            }
-            .buttonStyle(.plain)
-            .padding(.horizontal, 14).padding(.top, 10).padding(.bottom, 8)
-
-            if let gen = state.lastGenerated { generatedBox(gen) }
-
-            HStack(spacing: 16) {
-                linkButton("sparkles", "Set up a host…") {
-                    openWindow(id: HostSetupView.windowID)
-                }
-                linkButton("arrow.right.arrow.left", "Migrate…") {
-                    openWindow(id: MigrateView.windowID)
-                }
-            }
-            .padding(.horizontal, 14).padding(.bottom, 12)
+        HStack(spacing: 18) {
+            linkButton("plus", "New key…") { openWindow(id: HostSetupView.windowID) }
+            linkButton("arrow.right.arrow.left", "Migrate…") { openWindow(id: MigrateView.windowID) }
         }
+        .padding(.horizontal, 14).padding(.vertical, 12)
     }
 
     private func linkButton(_ icon: String, _ title: String, _ action: @escaping () -> Void) -> some View {
@@ -256,44 +207,6 @@ struct ContentView: View {
             .font(.system(size: 12)).foregroundStyle(Theme.accent)
         }
         .buttonStyle(.plain)
-    }
-
-    private func generatedBox(_ gen: AppState.GeneratedKey) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("“\(gen.name)” created. Add this public key where you'll use it — a server's authorized_keys, or GitHub/GitLab:")
-                .font(.system(size: 11)).foregroundStyle(t.sub).fixedSize(horizontal: false, vertical: true)
-            HStack(spacing: 8) {
-                Text(gen.pubLine)
-                    .font(.system(size: 10, design: .monospaced)).foregroundStyle(t.text)
-                    .lineLimit(2).truncationMode(.middle)
-                    .padding(8).frame(maxWidth: .infinity, alignment: .leading)
-                    .background(RoundedRectangle(cornerRadius: 6).fill(t.fieldBg))
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(gen.pubLine, forType: .string)
-                } label: {
-                    Text("Copy").font(.system(size: 11, weight: .semibold)).foregroundStyle(Theme.accent)
-                }
-                .buttonStyle(.plain)
-            }
-            HStack(spacing: 14) {
-                Text("Use for:").font(.system(size: 11)).foregroundStyle(t.sub)
-                linkButton("sparkles", "a host…") { openWindow(id: HostSetupView.windowID) }
-                linkButton("signature", "commit signing…") {
-                    state.signingSetupKey = gen.name
-                    state.signingSetupHost = nil
-                    openWindow(id: SigningSetupView.windowID)
-                }
-            }
-        }
-        .padding(.horizontal, 14).padding(.bottom, 8)
-    }
-
-    private func generate() {
-        let name = newKeyName.trimmingCharacters(in: .whitespaces)
-        guard !name.isEmpty else { return }
-        state.generate(name: name, requireBiometry: newKeyBiometry)
-        newKeyName = ""
     }
 
     // MARK: Activity

--- a/Sources/FobApp/FobApp.swift
+++ b/Sources/FobApp/FobApp.swift
@@ -13,7 +13,7 @@ struct FobApp: App {
         }
         .menuBarExtraStyle(.window)
 
-        Window("Set up a host", id: HostSetupView.windowID) {
+        Window("New key", id: HostSetupView.windowID) {
             HostSetupView().environmentObject(state)
         }
         .windowResizability(.contentSize)

--- a/Sources/FobApp/HostSetupView.swift
+++ b/Sources/FobApp/HostSetupView.swift
@@ -12,7 +12,7 @@ struct HostSetupView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.openWindow) private var openWindow
 
-    private enum Mode: Hashable { case server, git }
+    private enum Mode: Hashable { case server, git, sign, bare }
 
     @State private var mode: Mode = .server
     @State private var alias = ""
@@ -31,14 +31,19 @@ struct HostSetupView: View {
     @State private var gitAlias = ""
     @State private var customHost = ""
 
+    // Sign / bare modes.
+    @State private var keyName = ""
+    @State private var bareResult: AppState.GeneratedKey?
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 10) {
                 FobKeyGlyph(size: 28)
-                Text(result == nil ? "Set up a host" : "Almost done")
-                    .font(.title2.weight(.semibold))
+                Text(headerTitle).font(.title2.weight(.semibold))
             }
-            if let result { resultView(result) } else { formView }
+            if let bareResult { bareResultView(bareResult) }
+            else if let result { resultView(result) }
+            else { formView }
         }
         .padding(22)
         .frame(width: 460)
@@ -49,12 +54,19 @@ struct HostSetupView: View {
     private var formView: some View {
         VStack(alignment: .leading, spacing: 14) {
             Picker("Kind", selection: $mode) {
-                Text("Server (SSH login)").tag(Mode.server)
+                Text("Server").tag(Mode.server)
                 Text("Git host").tag(Mode.git)
+                Text("Sign commits").tag(Mode.sign)
+                Text("Just a key").tag(Mode.bare)
             }
             .pickerStyle(.segmented).labelsHidden()
 
-            if mode == .server { serverForm } else { gitForm }
+            switch mode {
+            case .server: serverForm
+            case .git: gitForm
+            case .sign: signForm
+            case .bare: bareForm
+            }
 
             if let error {
                 Label(error, systemImage: "exclamationmark.triangle.fill")
@@ -64,7 +76,7 @@ struct HostSetupView: View {
             HStack {
                 Spacer()
                 Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
-                Button("Set up") { setUp() }
+                Button(mode == .server || mode == .git ? "Set up" : "Create") { setUp() }
                     .keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
                     .disabled(!formValid)
             }
@@ -125,6 +137,50 @@ struct HostSetupView: View {
         }
     }
 
+    private var signForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("A dedicated Secure Enclave key for signing git commits. Next you'll register it on your git host as a **Signing Key** and configure git — Touch ID on each commit, no on-disk key to steal.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
+                field("Key name", "commit-signing", $keyName)
+            }
+            Toggle("Touch ID only (currently enrolled fingerprints)", isOn: $touchIDOnly)
+                .toggleStyle(.checkbox).font(.callout)
+        }
+    }
+
+    private var bareForm: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Just creates the Secure Enclave key. You'll add its public key wherever you need it (a server, a git host, or commit signing). Advanced — the guided options above wire it up for you.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
+                field("Key name", "mykey", $keyName)
+            }
+            Toggle("Touch ID only (currently enrolled fingerprints)", isOn: $touchIDOnly)
+                .toggleStyle(.checkbox).font(.callout)
+        }
+    }
+
+    private var headerTitle: String {
+        if result != nil { return "Almost done" }
+        if bareResult != nil { return "Key created" }
+        return "New key"
+    }
+
+    private func bareResultView(_ gen: AppState.GeneratedKey) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Key “\(gen.name)” created", systemImage: "checkmark.seal.fill")
+                .foregroundStyle(.green).font(.headline)
+            Text("Add this public key wherever you'll use it — a server's `authorized_keys`, or a git host (as an Authentication or a Signing key):")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            commandBox(gen.pubLine)
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
     private func providerHost() -> String {
         switch provider {
         case .github: return "github.com"
@@ -143,15 +199,47 @@ struct HostSetupView: View {
     }
 
     private var formValid: Bool {
-        if mode == .git {
+        switch mode {
+        case .git:
             let hostOK = provider != .other || !customHost.trimmingCharacters(in: .whitespaces).isEmpty
             return hostOK && !gitAlias.trimmingCharacters(in: .whitespaces).isEmpty
+        case .sign, .bare:
+            return !keyName.trimmingCharacters(in: .whitespaces).isEmpty
+        case .server:
+            return [alias, host, user].allSatisfy { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         }
-        return [alias, host, user].allSatisfy { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+    }
+
+    /// Create/reuse the key for the sign/bare modes; returns the trimmed name on success.
+    private func createKeyForName() -> String? {
+        let name = keyName.trimmingCharacters(in: .whitespaces)
+        guard KeyStore.isValidName(name) else {
+            error = "Invalid key name — letters, digits, '.', '_', '-' (not starting with '-')."
+            return nil
+        }
+        state.generate(name: name, requireBiometry: touchIDOnly)
+        if let err = state.actionError { error = err; return nil }
+        error = nil
+        return name
     }
 
     private func setUp() {
-        if mode == .git { setUpGit(); return }
+        switch mode {
+        case .git: setUpGit(); return
+        case .sign:
+            guard let name = createKeyForName() else { return }
+            state.signingSetupKey = name
+            state.signingSetupHost = nil
+            dismiss()
+            NSApp.activate(ignoringOtherApps: true)
+            openWindow(id: SigningSetupView.windowID)
+            return
+        case .bare:
+            if createKeyForName() != nil { bareResult = state.lastGenerated }
+            return
+        case .server:
+            break
+        }
         let trimmedPort = portText.trimmingCharacters(in: .whitespaces)
         guard let port = Int(trimmedPort.isEmpty ? "22" : trimmedPort) else {
             error = "Port must be a number (1–65535)."; return

--- a/Sources/FobApp/MigrateHostView.swift
+++ b/Sources/FobApp/MigrateHostView.swift
@@ -68,7 +68,11 @@ struct MigrateHostView: View {
     @ViewBuilder
     private func content(_ c: AppState.MigrationCandidate) -> some View {
         if c.isGitHost {
-            gitHostContent(c)
+            // Re-entry to retire (fob key present AND an old key still active) skips the
+            // add-to-account dance; a fresh git host (usesFob just written by New key, no
+            // old key) still needs it.
+            if c.usesFob && !c.oldIdentityFiles.isEmpty { gitMigratedContent(c) }
+            else { gitHostContent(c) }
         } else if alreadyMigrated {
             migratedContent(c)
         } else {
@@ -176,6 +180,41 @@ struct MigrateHostView: View {
                     NSApp.activate(ignoringOtherApps: true)
                     openWindow(id: SigningSetupView.windowID)
                 }
+            }
+        }
+    }
+
+    /// Re-entry for a git host already using fob with an old key still present: retire it
+    /// directly (no add-to-account), with an optional re-verify.
+    @ViewBuilder
+    private func gitMigratedContent(_ c: AppState.MigrationCandidate) -> some View {
+        Label("“\(alias)” already uses a fob key on \(c.provider.displayName). Retire the old key whenever you're ready — it stays a fallback until you do.",
+              systemImage: "checkmark.seal.fill")
+            .font(.callout).foregroundStyle(.green).fixedSize(horizontal: false, vertical: true)
+
+        step(1, "Verify fob works (optional)") {
+            Button(busy ? "Connecting…" : "Verify \(alias)") { runVerifyGit(c) }
+                .disabled(busy)
+            if let verified {
+                Label(verified.text, systemImage: verified.ok ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(verified.ok ? .green : .red).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+
+        step(2, "Retire the old key") {
+            Text("Comments the old key out of `~/.ssh/config` (fob is already preferred). It stays on your \(c.provider.displayName) account until you remove it there too.")
+                .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 10) {
+                Button(retired?.ok == true ? "Retired ✓" : "Retire old key") { runRetire() }
+                    .disabled(retired?.ok == true || busy).buttonStyle(.borderedProminent)
+                if let retired {
+                    Text(retired.text).font(.caption)
+                        .foregroundStyle(retired.ok ? .green : .red).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            if let url = c.settingsURL {
+                Button("Open \(c.provider.displayName) SSH keys (remove the old one)") { state.openSettings(url) }
+                    .font(.caption)
             }
         }
     }

--- a/Sources/FobApp/MigrateView.swift
+++ b/Sources/FobApp/MigrateView.swift
@@ -51,6 +51,7 @@ struct MigrateView: View {
         .padding(22)
         .frame(width: 480)
         .onAppear(perform: load)
+        .onChange(of: state.configRevision) { _ in load() }
     }
 
     private func load() {

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -96,7 +96,7 @@ struct SigningSetupView: View {
         } else {
             HStack(spacing: 10) {
                 Button(configureButtonTitle) {
-                    if let err = state.configureGitSigning(pubPath: info.pubPath, signerProgram: info.signerProgram, scope: scope) {
+                    if let err = state.configureGitSigning(pubPath: info.pubPath, signerProgram: info.signerProgram, pubLine: info.pubLine, scope: scope) {
                         gitError = err; gitConfigured = false
                     } else { gitConfigured = true; gitError = nil }
                 }

--- a/Sources/FobKit/SSHCheckup.swift
+++ b/Sources/FobKit/SSHCheckup.swift
@@ -89,11 +89,124 @@ public enum SSHCheckup {
         return contents[b.upperBound..<e.lowerBound].split(whereSeparator: \.isNewline).joined()
     }
 
+    // MARK: - Unencrypted on-disk key
+
+    /// Is `keyPath` still referenced by an active `IdentityFile` in ssh config, or by the
+    /// git signing key? Matched by exact filename (so `id_ed25519` ≠ `id_ed25519_perso`).
+    public static func isKeyReferenced(keyPath: String, configText: String, gitSigningKey: String?) -> Bool {
+        // Compare by filename, ignoring a `.pub` suffix so a private key matches its
+        // public-key reference (a signing key or IdentityFile is usually the `.pub`).
+        func norm(_ p: String) -> String {
+            let b = (p as NSString).lastPathComponent
+            return b.hasSuffix(".pub") ? String(b.dropLast(4)) : b
+        }
+        let base = norm(keyPath)
+        if let s = gitSigningKey, norm(s) == base { return true }
+        for raw in configText.split(separator: "\n") {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard line.lowercased().hasPrefix("identityfile") else { continue }
+            let value = line.dropFirst("identityfile".count)
+                .trimmingCharacters(in: CharacterSet(charactersIn: " \t=\""))
+            if norm(value) == base { return true }
+        }
+        return false
+    }
+
+    /// Finding for an unencrypted on-disk private key. If nothing references it, steer the
+    /// user to delete it (they've likely migrated off it); otherwise, to protect it.
+    public static func unencryptedKeyFinding(name: String, path: String, referenced: Bool) -> Finding {
+        if referenced {
+            return Finding(severity: .high, category: "Key", title: "“\(name)” has no passphrase",
+                detail: "This private key is stored unencrypted — anyone who reads the file (a backup, a stolen laptop, malware running as you) gets a working key. Add a passphrase, or move the hosts that use it to a fob key (Secure Enclave keys can't be copied off the machine).",
+                fix: .command("ssh-keygen -p -f \(path)"))
+        }
+        return Finding(severity: .high, category: "Key", title: "“\(name)” is unencrypted and unused",
+            detail: "This private key is stored unencrypted and no ~/.ssh/config host or your git signing config references it — you've likely migrated off it to fob. Delete it, and remove it from any account/server that still trusts it.",
+            fix: .command("rm \(path) \(path).pub"))
+    }
+
+    // MARK: - allowed_signers (local commit-signature verification)
+
+    /// Build/inspect `~/.ssh/allowed_signers` entries. Format: `<principals> [options]
+    /// <keytype> <base64> [comment]`. fob writes `<email> namespaces="git" <pubLine>`.
+    public enum AllowedSigners {
+        /// "<keytype> <base64>" from a public-key line, for presence checks.
+        public static func keyFields(_ pubLine: String) -> String? {
+            let parts = pubLine.split(separator: " ")
+            guard parts.count >= 2 else { return nil }
+            return "\(parts[0]) \(parts[1])"
+        }
+
+        public static func contains(_ fileText: String, pubLine: String) -> Bool {
+            guard let kf = keyFields(pubLine) else { return false }
+            return fileText.contains(kf)
+        }
+
+        public static func entry(email: String, pubLine: String) -> String {
+            "\(email) namespaces=\"git\" \(pubLine)"
+        }
+
+        /// Append an entry for this key/email if not already present; nil = already there.
+        public static func appending(_ fileText: String, email: String, pubLine: String) -> String? {
+            guard !contains(fileText, pubLine: pubLine) else { return nil }
+            let sep = fileText.isEmpty || fileText.hasSuffix("\n") ? "" : "\n"
+            return fileText + sep + entry(email: email, pubLine: pubLine) + "\n"
+        }
+    }
+
+    /// Flag when fob-signed commits can't be verified LOCALLY (GitHub's Verified is
+    /// separate). Either the allowed_signers file isn't configured, or the key isn't in it.
+    public static func signingVerificationFinding(usesFobSigning: Bool,
+                                                  allowedSignersConfigured: Bool,
+                                                  keyListed: Bool) -> Finding? {
+        guard usesFobSigning else { return nil }
+        if !allowedSignersConfigured {
+            return Finding(severity: .medium, category: "Config",
+                title: "Signed commits aren't verifiable locally",
+                detail: "You sign commits with a fob key, but git's gpg.ssh.allowedSignersFile isn't set — `git log --show-signature` / `git verify-commit` can't check your own signatures (your git host still shows Verified). Point git at an allowed_signers file.",
+                fix: .command("git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers"))
+        }
+        if !keyListed {
+            return Finding(severity: .medium, category: "Config",
+                title: "Your signing key isn't in allowed_signers",
+                detail: "Your fob signing key isn't listed in allowed_signers, so `git verify-commit` shows your commits unverified locally. Re-run a key's ••• → “Use for commit signing…” — fob adds it for you.",
+                fix: .none)
+        }
+        return nil
+    }
+
     // MARK: - File permissions
 
     /// A private key readable by group or other (`mode & 0o077 != 0`) — ssh itself refuses
     /// these, and it means another local account could read the key.
     public static func isPrivateKeyPermissive(mode: Int) -> Bool { mode & 0o077 != 0 }
+
+    // MARK: - Git identity footgun (multi-account default leak)
+
+    /// With multiple `includeIf` git identities but `user.useConfigOnly` unset, any repo
+    /// outside those directories silently commits/signs as the global default identity —
+    /// the class of bug that leaks the wrong account's email into a repo. nil = safe (no
+    /// includes, or the guard is already on).
+    public static func identityFinding(includeCount: Int, useConfigOnly: Bool,
+                                       defaultEmail: String?) -> Finding? {
+        guard includeCount > 0 else { return nil }
+        let hasGlobalEmail = defaultEmail?.isEmpty == false
+        // If there's no global user.email, useConfigOnly alone is the fix (git errors when
+        // it can't find one). If a global email IS set, useConfigOnly won't help — git will
+        // keep using that email; the identity has to be relocated into an includeIf.
+        if !hasGlobalEmail {
+            guard !useConfigOnly else { return nil }
+            return Finding(severity: .medium, category: "Config",
+                title: "Repos outside your includeIf directories have no identity guard",
+                detail: "You keep \(includeCount) per-directory git \(includeCount == 1 ? "identity" : "identities"). Set user.useConfigOnly so git refuses to invent an identity for a repo outside them, instead of guessing one from your system.",
+                fix: .command("git config --global user.useConfigOnly true"))
+        }
+        return Finding(severity: .medium, category: "Config",
+            title: "Repos outside your includeIf directories commit as \(defaultEmail!)",
+            detail: "Git uses your global default identity (\(defaultEmail!)) for any repo outside your \(includeCount) includeIf \(includeCount == 1 ? "directory" : "directories") — a clone in /tmp or ~/Downloads would commit (and sign) as the wrong account. Fix in two steps: move your default identity into its own includeIf (e.g. gitdir:~/work/), THEN set user.useConfigOnly=true — so a repo matching no include has no identity and git errors instead of defaulting. (Setting useConfigOnly alone won't help while a global user.email is set.)",
+            fix: .command("git config --global user.useConfigOnly true"))
+    }
 
     // MARK: - Risky ~/.ssh/config directives
 

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -136,8 +136,10 @@ func sshCheckupFindings() -> [SSHCheckup.Finding] {
         guard let contents = try? String(contentsOfFile: path, encoding: .utf8),
               let info = SSHCheckup.parsePrivateKey(contents) else { continue }
         if !info.isEncrypted {
-            findings.append(.init(severity: .high, category: "Key", title: "“\(name)” has no passphrase",
-                detail: "Stored unencrypted — a copy of the file is a working key. Add a passphrase (ssh-keygen -p -f \(path)) or move its hosts to fob.", fix: .none))
+            let cfg = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
+            let gitSigning = GitConfig.parse((try? String(contentsOf: home.appendingPathComponent(".gitconfig"), encoding: .utf8)) ?? "").signingKey
+            let referenced = SSHCheckup.isKeyReferenced(keyPath: path, configText: cfg, gitSigningKey: gitSigning)
+            findings.append(SSHCheckup.unencryptedKeyFinding(name: name, path: path, referenced: referenced))
         }
         if let mode = (try? fm.attributesOfItem(atPath: path))?[.posixPermissions] as? Int,
            SSHCheckup.isPrivateKeyPermissive(mode: mode) {
@@ -157,6 +159,13 @@ func sshCheckupFindings() -> [SSHCheckup.Finding] {
     let config = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
     findings += SSHCheckup.scanConfig(config)
 
+    let includeCount = GitConfig.parseIncludeEntries(gitIncludeRegexp()).count
+    if let f = SSHCheckup.identityFinding(includeCount: includeCount,
+                                          useConfigOnly: gitConfigGlobal("user.useConfigOnly") == "true",
+                                          defaultEmail: gitConfigGlobal("user.email")) {
+        findings.append(f)
+    }
+
     for block in HostSetup.listHostBlocks(in: config) where !block.usesFob {
         findings.append(.init(severity: .opportunity, category: "Opportunity",
             title: "“\(block.alias)” still uses an on-disk key",
@@ -169,7 +178,32 @@ func sshCheckupFindings() -> [SSHCheckup.Finding] {
             title: "Commit signing uses a non-fob key",
             detail: "Set up a fob signing key:  fob sign-setup <key>", fix: .none))
     }
+    if signing.usesFob {
+        let asFile = gitConfigGlobal("gpg.ssh.allowedSignersFile")
+        var keyListed = false
+        if !asFile.isEmpty, let sk = signing.signingKey {
+            let asText = (try? String(contentsOfFile: (asFile as NSString).expandingTildeInPath, encoding: .utf8)) ?? ""
+            let pub = (try? String(contentsOfFile: (sk as NSString).expandingTildeInPath, encoding: .utf8)) ?? ""
+            keyListed = SSHCheckup.AllowedSigners.contains(asText, pubLine: pub)
+        }
+        if let f = SSHCheckup.signingVerificationFinding(
+            usesFobSigning: true, allowedSignersConfigured: !asFile.isEmpty, keyListed: keyListed) {
+            findings.append(f)
+        }
+    }
     return findings.sorted { $0.severity < $1.severity }
+}
+
+/// A single `git config --global <key>` value (trimmed; "" if unset/failure).
+func gitConfigGlobal(_ key: String) -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    process.arguments = ["config", "--global", key]
+    let pipe = Pipe(); process.standardOutput = pipe; process.standardError = Pipe()
+    guard (try? process.run()) != nil else { return "" }
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    process.waitUntilExit()
+    return String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
 }
 
 /// Raw output of `git config --global --get-regexp '^includeif\.'` ("" on failure).
@@ -371,6 +405,14 @@ do {
         print("")
         print("3. (recommended) restrict this key to git signatures only:")
         print("     fob namespaces \(name) git")
+        print("")
+        let signEmail = gitConfigGlobal("user.email").trimmingCharacters(in: .whitespacesAndNewlines)
+        let signerId = signEmail.isEmpty ? "<your-email>" : signEmail
+        print("4. (local verification) so `git verify-commit` and `git log --show-signature`")
+        print("   trust it, point git at an allow-list (safe to set globally) …")
+        print("     git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers")
+        print("   … and add this key to that file:")
+        print("     \(SSHCheckup.AllowedSigners.entry(email: signerId, pubLine: pubLine))")
         print("")
         print("Then `git commit` prompts Touch ID via fob, and your host (GitHub, GitLab,")
         print("Gitea/Forgejo, …) shows \"Verified\". It also verifies locally via allowed_signers.")

--- a/Tests/FobKitTests/CheckupTests.swift
+++ b/Tests/FobKitTests/CheckupTests.swift
@@ -71,6 +71,68 @@ final class CheckupTests: XCTestCase {
         XCTAssertTrue(SSHCheckup.isPrivateKeyPermissive(mode: 0o660))
     }
 
+    // MARK: - isKeyReferenced / unencryptedKeyFinding
+
+    func testIsKeyReferenced() {
+        let config = """
+        Host a
+          IdentityFile ~/.ssh/id_ed25519_perso_ousson
+        Host b
+          # IdentityFile ~/.ssh/id_ed25519
+          IdentityFile ~/.ssh/fob_b.pub
+        """
+        // id_ed25519 is only in a COMMENTED line → not referenced (and not confused with
+        // the substring match against id_ed25519_perso_ousson).
+        XCTAssertFalse(SSHCheckup.isKeyReferenced(keyPath: "/Users/me/.ssh/id_ed25519", configText: config, gitSigningKey: nil))
+        // the perso key IS active
+        XCTAssertTrue(SSHCheckup.isKeyReferenced(keyPath: "/Users/me/.ssh/id_ed25519_perso_ousson", configText: config, gitSigningKey: nil))
+        // referenced via git signing key
+        XCTAssertTrue(SSHCheckup.isKeyReferenced(keyPath: "/Users/me/.ssh/id_ed25519", configText: "", gitSigningKey: "/Users/me/.ssh/id_ed25519.pub"))
+    }
+
+    func testUnencryptedKeyFindingWording() {
+        XCTAssertTrue(SSHCheckup.unencryptedKeyFinding(name: "k", path: "/p", referenced: true).fix == .command("ssh-keygen -p -f /p"))
+        let unused = SSHCheckup.unencryptedKeyFinding(name: "k", path: "/p", referenced: false)
+        XCTAssertTrue(unused.title.contains("unused"))
+        XCTAssertEqual(unused.fix, .command("rm /p /p.pub"))
+    }
+
+    // MARK: - identityFinding
+
+    func testIdentityFinding() {
+        // global email set → flag (useConfigOnly alone insufficient), even if useConfigOnly on
+        let f = SSHCheckup.identityFinding(includeCount: 2, useConfigOnly: false, defaultEmail: "me@work.com")
+        XCTAssertNotNil(f)
+        XCTAssertTrue(f?.title.contains("me@work.com") == true)
+        XCTAssertTrue(f?.detail.contains("two steps") == true || f?.detail.contains("relocate") == true || f?.detail.contains("includeIf") == true)
+        // no global email + guard off → bare useConfigOnly is the fix
+        let g = SSHCheckup.identityFinding(includeCount: 2, useConfigOnly: false, defaultEmail: "")
+        XCTAssertEqual(g?.fix, .command("git config --global user.useConfigOnly true"))
+        // no global email + guard on → nil
+        XCTAssertNil(SSHCheckup.identityFinding(includeCount: 2, useConfigOnly: true, defaultEmail: ""))
+        // no includes → nil
+        XCTAssertNil(SSHCheckup.identityFinding(includeCount: 0, useConfigOnly: false, defaultEmail: "me@work.com"))
+    }
+
+    func testAllowedSigners() {
+        let pub = "ecdsa-sha2-nistp256 AAAABBBCCC fob:x"
+        XCTAssertEqual(SSHCheckup.AllowedSigners.keyFields(pub), "ecdsa-sha2-nistp256 AAAABBBCCC")
+        XCTAssertEqual(SSHCheckup.AllowedSigners.entry(email: "me@x.com", pubLine: pub),
+                       "me@x.com namespaces=\"git\" ecdsa-sha2-nistp256 AAAABBBCCC fob:x")
+        XCTAssertFalse(SSHCheckup.AllowedSigners.contains("", pubLine: pub))
+        let added = SSHCheckup.AllowedSigners.appending("", email: "me@x.com", pubLine: pub)
+        XCTAssertNotNil(added)
+        XCTAssertTrue(SSHCheckup.AllowedSigners.contains(added!, pubLine: pub))
+        XCTAssertNil(SSHCheckup.AllowedSigners.appending(added!, email: "me@x.com", pubLine: pub)) // idempotent
+    }
+
+    func testSigningVerificationFinding() {
+        XCTAssertNil(SSHCheckup.signingVerificationFinding(usesFobSigning: false, allowedSignersConfigured: false, keyListed: false))
+        XCTAssertTrue(SSHCheckup.signingVerificationFinding(usesFobSigning: true, allowedSignersConfigured: false, keyListed: false)?.title.contains("verifiable") == true)
+        XCTAssertTrue(SSHCheckup.signingVerificationFinding(usesFobSigning: true, allowedSignersConfigured: true, keyListed: false)?.title.contains("allowed_signers") == true)
+        XCTAssertNil(SSHCheckup.signingVerificationFinding(usesFobSigning: true, allowedSignersConfigured: true, keyListed: true))
+    }
+
     // MARK: - scanConfig
 
     func testScanFlagsRiskyDirectives() {


### PR DESCRIPTION
The feat/new-key-flow branch is committed (4a90ff2, fob-signed ✓, authored as ousson, no AI footer) and pushed. It bundles:

- Unified "New key…" wizard — one entry with four purposes (Server · Git host · Sign commits · Just a key), replacing the three old creation doors. Standalone signing no longer requires creating an auth key first.
- Panel consolidation — NEW KEY field + Set up a host… → New key… / Migrate…; per-key actions stay on ••• .
- allowed_signers management — configuring a fob signing key now sets gpg.ssh.allowedSignersFile globally and appends the key entry so git verify-commit works locally; fob sign-setup prints the entry + guidance.
- Two new checkup findings — the git-identity guard (with the corrected two-step useConfigOnly advice you flagged) and signing-verifiability.
- Plus the migrate auto-refresh, direct git-host retire, and pin/attribution alias fixes.