### PR TITLE
Consolidate the five task windows into one "fob" Configure window

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -37,6 +37,23 @@ final class AppState: ObservableObject {
     /// Bumped after any ~/.ssh/config write so open lists (e.g. Migrate) refresh live.
     @Published var configRevision = 0
 
+    // MARK: - Config window routing
+    // The single "fob" window shows one of these tabs; two flows (signing, migrate-a-host)
+    // are reached from other flows/the popover, so they render as a pushed detail over the
+    // current tab rather than as tabs of their own.
+    enum ConfigTab: Hashable { case newKey, keys, migrate, checkup, audit, settings }
+    enum ConfigDetail: Equatable { case signing, migrateHost }
+    @Published var configTab: ConfigTab = .newKey
+    @Published var configDetail: ConfigDetail?
+
+    /// Set the config window's route, then the caller opens the window. Detail routes reuse
+    /// the existing `signingSetupKey`/`migrateAlias` fields as their parameters (set those
+    /// first). Passing a tab clears any active detail.
+    func openConfig(tab: ConfigTab, detail: ConfigDetail? = nil) {
+        configTab = tab
+        configDetail = detail
+    }
+
     private let store: KeyStore?
     private var agent: Agent?
     private static let feedLimit = 40
@@ -130,6 +147,41 @@ final class AppState: ObservableObject {
 
     func delete(name: String) {
         run { store in try store.remove(name: name) }
+        // Only tidy the key's config/pub if the enclave key was actually erased — a failed
+        // remove must not leave the key alive while stripping its ~/.ssh/config entry.
+        if actionError == nil { cleanupAfterDelete(name) }
+    }
+
+    /// After erasing the enclave key, clear what fob wrote for it: the exported public key
+    /// and — if this alias had a fob-created `~/.ssh/config` block — that block (backed up
+    /// first). Otherwise the dead entry lingers and re-appears in Migrate (the confusion
+    /// this fixes). A migrated host with a live old key is left untouched by removeFobHostBlock.
+    private func cleanupAfterDelete(_ name: String) {
+        let ssh = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+        try? FileManager.default.removeItem(at: ssh.appendingPathComponent("fob_\(name).pub"))
+        let cfg = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        if let new = HostSetup.removeFobHostBlock(cfg, alias: name), new != cfg {
+            _ = try? HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
+            configRevision += 1
+        }
+    }
+
+    /// Remove a single fob `Host <alias>` block from ~/.ssh/config (backup first) — used by
+    /// the Keys page to prune a redundant SSH auth alias on a signing-only key. Returns an
+    /// error string, or nil on success (also nil-safe: a migrated host with a live old key
+    /// isn't removable and returns a message rather than touching it). Bumps configRevision.
+    func removeSSHHostAlias(_ alias: String) -> String? {
+        let cfg = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        guard let new = HostSetup.removeFobHostBlock(cfg, alias: alias), new != cfg else {
+            return "Couldn’t remove “\(alias)” — it isn’t a plain fob host block."
+        }
+        do {
+            _ = try HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
+            configRevision += 1
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
     }
 
     /// Confirm-then-delete via an AppKit alert. A SwiftUI `confirmationDialog` fired
@@ -142,7 +194,8 @@ final class AppState: ObservableObject {
             let alert = NSAlert()
             alert.messageText = "Delete key “\(name)”?"
             alert.informativeText =
-                "The Secure Enclave key is erased permanently and cannot be recovered."
+                "The Secure Enclave key is erased permanently and cannot be recovered. "
+                + "fob also removes its exported public key and its ~/.ssh/config entry (backed up first)."
             alert.alertStyle = .critical
             alert.addButton(withTitle: "Delete")
             alert.addButton(withTitle: "Cancel")
@@ -322,6 +375,64 @@ final class AppState: ObservableObject {
     func gitSigningInfo() -> GitConfig.SigningInfo {
         let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".gitconfig")
         return GitConfig.parse((try? String(contentsOf: url, encoding: .utf8)) ?? "")
+    }
+
+    /// What a key is actually used for, so the Keys page can tailor its row (e.g. hide
+    /// "Sign commits…" for a key that already signs, or "Pin" for a signing-only key).
+    struct KeyUsage: Equatable {
+        let signsCommits: Bool     // it's the git signing key (global or any includeIf identity)
+        let authHosts: [String]    // ~/.ssh/config aliases whose IdentityFile is this fob key
+        let authGitHosts: [String] // subset of authHosts that are git services (GitHub/GitLab/…)
+        var isSigningOnly: Bool { signsCommits && authHosts.isEmpty }
+        var isUnused: Bool { !signsCommits && authHosts.isEmpty }
+        /// Commit signing is a git concept — offer it for git-service keys or a bare key, not
+        /// for a plain server-login key where it's meaningless.
+        var canOfferSigning: Bool { !signsCommits && (isUnused || !authGitHosts.isEmpty) }
+    }
+
+    func keyUsage(name: String) -> KeyUsage {
+        let inputs = usageInputs()
+        return usage(for: name, inputs: inputs)
+    }
+
+    /// Usage for every key in one shot — shares the git/ssh reads across all keys so the
+    /// Keys tab doesn't spawn a subprocess storm (the source of the tab-open lag).
+    func keyUsages() -> [String: KeyUsage] {
+        let inputs = usageInputs()
+        var out: [String: KeyUsage] = [:]
+        for key in keys { out[key.name] = usage(for: key.name, inputs: inputs) }
+        return out
+    }
+
+    /// The shared, key-independent reads: the set of configured signing-key basenames
+    /// (global + every includeIf identity) and the parsed ssh `Host` blocks. Computed once.
+    private struct UsageInputs { let signingBases: Set<String>; let blocks: [HostSetup.HostBlock] }
+    private func usageInputs() -> UsageInputs {
+        func base(_ p: String) -> String {
+            (p.trimmingCharacters(in: .whitespacesAndNewlines) as NSString).lastPathComponent
+        }
+        var signing = Set<String>()
+        let g = base(runGitSync(["config", "--global", "user.signingkey"]))
+        if !g.isEmpty { signing.insert(g) }
+        for inc in GitConfig.parseIncludeEntries(runGitSync(["config", "--global", "--get-regexp", "^includeif\\."])) {
+            let b = base(runGitSync(["config", "--file", (inc.path as NSString).expandingTildeInPath, "user.signingkey"]))
+            if !b.isEmpty { signing.insert(b) }
+        }
+        let cfg = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        return UsageInputs(signingBases: signing, blocks: HostSetup.listHostBlocks(in: cfg))
+    }
+
+    private func usage(for name: String, inputs: UsageInputs) -> KeyUsage {
+        let pubBase = "fob_\(name).pub"
+        let mine = inputs.blocks.filter {
+            $0.parsed.identityFiles.contains { ($0 as NSString).lastPathComponent == pubBase }
+        }
+        let gitHosts = mine
+            .filter { HostSetup.isGitHost(hostName: $0.parsed.hostName ?? $0.alias, user: $0.parsed.user) }
+            .map(\.alias)
+        return KeyUsage(signsCommits: inputs.signingBases.contains(pubBase),
+                        authHosts: Array(Set(mine.map(\.alias))).sorted(),
+                        authGitHosts: Array(Set(gitHosts)).sorted())
     }
 
     /// Create (or reuse) the fob key, export its public key, and install it on the server
@@ -769,6 +880,7 @@ final class AppState: ObservableObject {
         }
     }
 
+
     /// Write the signing config to `scope` (global, or a specific include file for a
     /// multi-account identity). nil = success. `.repository` is not applied here — the
     /// window has no repo context, so those are shown as copy commands.
@@ -978,6 +1090,18 @@ final class AppState: ObservableObject {
         guard let store else { return }
         let url = AuditLog.logURL(directory: store.directory)
         NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    /// Audit entries, newest first, for the in-app Audit page ([] if the store is unavailable).
+    func auditEntries() -> [AuditLog.Entry] {
+        guard let store else { return [] }
+        return AuditLog.entries(directory: store.directory).reversed()
+    }
+
+    /// 1-based line of the first broken hash-chain link, or nil if the chain verifies.
+    func auditFirstBrokenLink() -> Int? {
+        guard let store else { return nil }
+        return AuditLog.firstBrokenLink(directory: store.directory)
     }
 }
 

--- a/Sources/FobApp/AuditView.swift
+++ b/Sources/FobApp/AuditView.swift
@@ -1,0 +1,128 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The Audit page: the hash-chained decision log, newest first, with a chain-integrity
+/// badge. Read-only — the log itself is append-only and tamper-evident; this just shows it
+/// and re-verifies the chain on demand.
+struct AuditView: View {
+    @EnvironmentObject var state: AppState
+
+    @State private var entries: [AuditLog.Entry] = []
+    @State private var brokenAt: Int?
+    @State private var loaded = false
+
+    private static let parser = ISO8601DateFormatter()
+    private static let display: DateFormatter = {
+        let f = DateFormatter(); f.dateFormat = "MMM d · h:mm:ss a"; return f
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Audit log").font(.title2.weight(.semibold))
+                Spacer()
+                chainBadge
+            }
+            Text("Every signature and decision is appended to a SHA-256 **hash chain** — editing or deleting any line breaks it. Tamper-evident, newest first.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+
+            if entries.isEmpty {
+                Text(loaded ? "No audit entries yet — nothing has used a key." : "Loading…")
+                    .font(.callout).foregroundStyle(.secondary).padding(.vertical, 20)
+            } else {
+                ScrollView {
+                    VStack(spacing: 6) {
+                        ForEach(Array(entries.enumerated()), id: \.offset) { _, e in row(e) }
+                    }
+                }
+                .frame(minHeight: 260, maxHeight: 460)
+            }
+
+            HStack {
+                Button("Verify chain") { load() }
+                Spacer()
+                Button("Reveal in Finder") { state.revealAuditLog() }
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear { if !loaded { load() } }
+    }
+
+    private var chainBadge: some View {
+        Group {
+            if let brokenAt {
+                Label("chain broken at line \(brokenAt)", systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Theme.red)
+            } else if !entries.isEmpty {
+                Label("chain intact", systemImage: "checkmark.seal.fill").foregroundStyle(Theme.green)
+            }
+        }
+        .font(.caption.weight(.semibold))
+    }
+
+    private func load() {
+        entries = state.auditEntries()
+        brokenAt = state.auditFirstBrokenLink()
+        loaded = true
+    }
+
+    private func row(_ e: AuditLog.Entry) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(eventLabel(e.event))
+                .font(.system(size: 9, weight: .bold)).tracking(0.4)
+                .padding(.horizontal, 5).padding(.vertical, 2)
+                .background(RoundedRectangle(cornerRadius: 4).fill(color(e.event).opacity(0.16)))
+                .foregroundStyle(color(e.event))
+                .frame(width: 96, alignment: .leading)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    if let key = e.key { Text(key).font(.callout.weight(.semibold)) }
+                    if let dest = e.dest, !dest.isEmpty {
+                        Text("→ \(dest)").font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Text(timestamp(e.ts)).font(.system(.caption2, design: .monospaced)).foregroundStyle(.secondary)
+                if let peer = e.peer, !peer.isEmpty {
+                    Text(peer).font(.system(.caption2, design: .monospaced)).foregroundStyle(.tertiary)
+                        .lineLimit(1).truncationMode(.middle)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+    }
+
+    private func timestamp(_ ts: String) -> String {
+        guard let date = Self.parser.date(from: ts) else { return ts }
+        return Self.display.string(from: date)
+    }
+
+    /// Short, human label for a raw event token (e.g. "signed-reused" → "REUSED").
+    private func eventLabel(_ event: String) -> String {
+        switch event {
+        case "signed": return "SIGNED"
+        case "signed-reused": return "REUSED"
+        case "signed-git": return "SIGNED GIT"
+        case "denied": return "DENIED"
+        case "refused-pin": return "REFUSED PIN"
+        case "refused-policy": return "REFUSED"
+        case "refused-namespace": return "REFUSED NS"
+        case "bind-rejected": return "BIND REJECT"
+        case "unknown-key": return "UNKNOWN KEY"
+        default: return event.uppercased()
+        }
+    }
+
+    private func color(_ event: String) -> Color {
+        if event.hasPrefix("signed") { return Theme.green }
+        if event == "denied" { return .orange }
+        if event.hasPrefix("refused") || event == "bind-rejected" { return Theme.red }
+        if event == "unknown-key" { return .yellow }
+        return .secondary
+    }
+}

--- a/Sources/FobApp/CheckupView.swift
+++ b/Sources/FobApp/CheckupView.swift
@@ -2,16 +2,12 @@ import AppKit
 import FobKit
 import SwiftUI
 
-/// The "SSH checkup" window: a read-only scan of ~/.ssh (keys, config) plus
+/// The "SSH checkup" page (a Configure-window tab): a read-only scan of ~/.ssh (keys, config) plus
 /// migrate/signing opportunities, shown as severity-ranked findings. Every fix is opt-in
 /// — it either opens an existing fob flow or copies a command; the checkup never edits
 /// anything itself.
 struct CheckupView: View {
-    static let windowID = "fob-checkup"
-
     @EnvironmentObject var state: AppState
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.openWindow) private var openWindow
 
     @State private var report: AppState.CheckupReport?
     @State private var running = false
@@ -45,13 +41,9 @@ struct CheckupView: View {
                 HStack { Spacer(); ProgressView(); Spacer() }.padding(.vertical, 20)
             }
 
-            HStack {
-                Spacer()
-                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
-            }
         }
         .padding(22)
-        .frame(width: 560)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { if report == nil { run() } }
     }
 
@@ -107,8 +99,7 @@ struct CheckupView: View {
         case .migrate(let alias):
             Button("Migrate \(alias)…") {
                 state.migrateAlias = alias
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: MigrateHostView.windowID)
+                state.configDetail = .migrateHost
             }.font(.caption).padding(.top, 2)
         case .signing:
             Text("Fix: a key's ••• → “Use for commit signing…”.")

--- a/Sources/FobApp/ConfigWindow.swift
+++ b/Sources/FobApp/ConfigWindow.swift
@@ -1,0 +1,79 @@
+import FobKit
+import SwiftUI
+
+/// The single "fob" window. A segmented tab bar picks one of the top-level pages
+/// (New key · Migrate · SSH checkup · Audit · Settings); Commit-signing and Migrate-a-host
+/// aren't tabs — they're entered from other flows/the popover, so they render as a pushed
+/// *detail* over the current tab with a Back button. Every former separate window is now a
+/// page here, so nothing spawns extra windows.
+struct ConfigWindow: View {
+    static let windowID = "fob-config"
+
+    @EnvironmentObject var state: AppState
+
+    private var tabBinding: Binding<AppState.ConfigTab> {
+        Binding(get: { state.configTab }, set: { state.configTab = $0 })
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .frame(width: 560)
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        if state.configDetail != nil {
+            HStack(spacing: 6) {
+                Button { state.configDetail = nil } label: {
+                    Label(backTitle, systemImage: "chevron.left").font(.callout.weight(.medium))
+                }
+                .buttonStyle(.plain).foregroundStyle(Color.accentColor)
+                Spacer()
+            }
+            .padding(.horizontal, 16).padding(.vertical, 10)
+        } else {
+            Picker("", selection: tabBinding) {
+                Text("New key").tag(AppState.ConfigTab.newKey)
+                Text("Keys").tag(AppState.ConfigTab.keys)
+                Text("Migrate").tag(AppState.ConfigTab.migrate)
+                Text("Checkup").tag(AppState.ConfigTab.checkup)
+                Text("Audit").tag(AppState.ConfigTab.audit)
+                Text("Settings").tag(AppState.ConfigTab.settings)
+            }
+            .pickerStyle(.segmented).labelsHidden()
+            .padding(.horizontal, 16).padding(.vertical, 10)
+        }
+    }
+
+    private var backTitle: String {
+        switch state.configTab {
+        case .keys: return "Keys"
+        case .migrate: return "Migrate"
+        case .checkup: return "Checkup"
+        default: return "New key"
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let detail = state.configDetail {
+            switch detail {
+            case .signing: SigningSetupView()
+            case .migrateHost: MigrateHostView()
+            }
+        } else {
+            switch state.configTab {
+            case .newKey: HostSetupView()
+            case .keys: KeysView()
+            case .migrate: MigrateView()
+            case .checkup: CheckupView()
+            case .audit: AuditView()
+            case .settings: SettingsView()
+            }
+        }
+    }
+}

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -57,6 +57,7 @@ struct ContentView: View {
     @Environment(\.openWindow) private var openWindow
 
     @State private var openMenuKey: String?
+    @State private var menuUsage: AppState.KeyUsage?
 
     private var t: Theme { Theme.current(scheme) }
     private let width: CGFloat = 360
@@ -146,8 +147,7 @@ struct ContentView: View {
             Text("fob keeps SSH keys in the Secure Enclave, unlocked by Touch ID. Already using SSH keys? Migrate a server — fob adds a new key alongside the old one and proves it works before you retire anything.")
                 .font(.system(size: 11.5)).foregroundStyle(t.sub).fixedSize(horizontal: false, vertical: true)
             Button {
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: MigrateView.windowID)
+                openConfigWindow(.migrate)
             } label: {
                 Text("Migrate an existing server…")
                     .font(.system(size: 12.5, weight: .semibold)).foregroundStyle(.white)
@@ -155,7 +155,7 @@ struct ContentView: View {
                     .background(RoundedRectangle(cornerRadius: 7).fill(Theme.accent))
             }
             .buttonStyle(.plain)
-            Text("…or **New key…** below to create one from scratch.")
+            Text("…or **Configure… → New key** to create one from scratch.")
                 .font(.system(size: 11)).foregroundStyle(t.sub)
         }
         .padding(.horizontal, 14).padding(.top, 2).padding(.bottom, 10)
@@ -189,16 +189,24 @@ struct ContentView: View {
 
     private var newKeySection: some View {
         HStack(spacing: 18) {
-            linkButton("plus", "New key…") {
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: HostSetupView.windowID)
-            }
-            linkButton("arrow.right.arrow.left", "Migrate…") {
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: MigrateView.windowID)
-            }
+            linkButton("slider.horizontal.3", "Configure…") { openConfigWindow(.newKey) }
+            Spacer()
         }
         .padding(.horizontal, 14).padding(.vertical, 12)
+    }
+
+    /// Set the config window's route and bring it up (all popover flows funnel through here).
+    private func openConfigWindow(_ tab: AppState.ConfigTab, detail: AppState.ConfigDetail? = nil) {
+        state.openConfig(tab: tab, detail: detail)
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: ConfigWindow.windowID)
+    }
+
+    /// Open the signing page in the config window for this key (from the ••• menu).
+    private func openSigning(_ name: String) {
+        state.signingSetupKey = name
+        state.signingSetupHost = nil
+        openConfigWindow(.newKey, detail: .signing)
     }
 
     private func linkButton(_ icon: String, _ title: String, _ action: @escaping () -> Void) -> some View {
@@ -252,27 +260,11 @@ struct ContentView: View {
     // MARK: Footer
 
     private var footer: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text("Launch at login").font(.system(size: 12)).foregroundStyle(t.text)
-                Spacer()
-                Toggle("", isOn: Binding(get: { state.launchAtLogin },
-                                         set: { state.setLaunchAtLogin($0) }))
-                    .labelsHidden().toggleStyle(.switch).tint(Theme.green)
-            }
-            .padding(.horizontal, 14).padding(.vertical, 11)
-            divider
-            HStack {
-                footerButton("SSH checkup") {
-                    NSApp.activate(ignoringOtherApps: true)
-                    openWindow(id: CheckupView.windowID)
-                }
-                footerButton("Reveal audit log") { state.revealAuditLog() }
-                Spacer()
-                footerButton("Quit fob") { NSApplication.shared.terminate(nil) }
-            }
-            .padding(.horizontal, 12).padding(.vertical, 9)
+        HStack {
+            Spacer()
+            footerButton("Quit fob") { NSApplication.shared.terminate(nil) }
         }
+        .padding(.horizontal, 12).padding(.vertical, 9)
     }
 
     private func footerButton(_ title: String, _ action: @escaping () -> Void) -> some View {
@@ -288,7 +280,11 @@ struct ContentView: View {
     // MARK: Dropdown
 
     private func toggleMenu(_ name: String) {
-        openMenuKey = (openMenuKey == name) ? nil : name
+        let opening = openMenuKey != name
+        openMenuKey = opening ? name : nil
+        // Compute usage once, only for the key whose menu is opening, so the dropdown can
+        // scope the signing item (git concept) without pricing it into every key's render.
+        menuUsage = opening ? state.keyUsage(name: name) : nil
     }
 
     @ViewBuilder
@@ -321,12 +317,13 @@ struct ContentView: View {
             if key.isPinned {
                 menuItem("Unpin (any destination)", color: t.text) { state.unpin(name: key.name) }
             }
-            menuItem("Pin to host…", color: t.text) { state.requestPin(name: key.name) }
-            menuItem("Use for commit signing…", color: t.text) {
-                state.signingSetupKey = key.name
-                state.signingSetupHost = nil
-                NSApp.activate(ignoringOtherApps: true)
-                openWindow(id: SigningSetupView.windowID)
+            if !(menuUsage?.isSigningOnly ?? false) {
+                menuItem("Pin to host…", color: t.text) { state.requestPin(name: key.name) }
+            }
+            if menuUsage?.signsCommits ?? false {
+                menuItem("Signing setup…", color: t.text) { openSigning(key.name) }
+            } else if menuUsage?.canOfferSigning ?? true {
+                menuItem("Use for commit signing…", color: t.text) { openSigning(key.name) }
             }
             menuItem("Delete…", color: Theme.red) { state.requestDelete(name: key.name) }
         }

--- a/Sources/FobApp/FobApp.swift
+++ b/Sources/FobApp/FobApp.swift
@@ -13,30 +13,10 @@ struct FobApp: App {
         }
         .menuBarExtraStyle(.window)
 
-        Window("New key", id: HostSetupView.windowID) {
-            HostSetupView().environmentObject(state).followsActiveSpace()
+        Window("fob", id: ConfigWindow.windowID) {
+            ConfigWindow().environmentObject(state).followsActiveSpace()
         }
         .windowResizability(.contentSize)
-
-        Window("Commit signing", id: SigningSetupView.windowID) {
-            SigningSetupView().environmentObject(state).followsActiveSpace()
-        }
-        .windowResizability(.contentSize)
-
-        Window("Migrate to fob", id: MigrateView.windowID) {
-            MigrateView().environmentObject(state).followsActiveSpace()
-        }
-        .windowResizability(.contentSize)
-
-        Window("Migrate a server", id: MigrateHostView.windowID) {
-            MigrateHostView().environmentObject(state).followsActiveSpace()
-        }
-        .windowResizability(.contentSize)
-
-        Window("SSH checkup", id: CheckupView.windowID) {
-            CheckupView().environmentObject(state).followsActiveSpace()
-        }
-        .windowResizability(.contentMinSize)
     }
 }
 

--- a/Sources/FobApp/HostSetupView.swift
+++ b/Sources/FobApp/HostSetupView.swift
@@ -2,15 +2,12 @@ import AppKit
 import FobKit
 import SwiftUI
 
-/// The "Set up a host" window: generate a key, write the `~/.ssh/config` entry, and hand
-/// the user the one command to run on the server. It deliberately does NOT run
-/// `ssh-copy-id` itself — ssh reads the server password from a TTY the app doesn't have.
+/// The "New key" page (the Configure window's first tab): a mode picker — Server · Git host ·
+/// Sign commits · Just a key — that generates a Secure Enclave key and hands off to the right
+/// flow. For a server it writes the `~/.ssh/config` entry and shows the one command to run on
+/// the box (it deliberately does NOT run `ssh-copy-id` — ssh needs a TTY the app doesn't have).
 struct HostSetupView: View {
-    static let windowID = "fob-host-setup"
-
     @EnvironmentObject var state: AppState
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.openWindow) private var openWindow
 
     private enum Mode: Hashable { case server, git, sign, bare }
 
@@ -46,7 +43,7 @@ struct HostSetupView: View {
             else { formView }
         }
         .padding(22)
-        .frame(width: 460)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: Form
@@ -75,7 +72,6 @@ struct HostSetupView: View {
 
             HStack {
                 Spacer()
-                Button("Cancel") { dismiss() }.keyboardShortcut(.cancelAction)
                 Button(mode == .server || mode == .git ? "Set up" : "Create") { setUp() }
                     .keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
                     .disabled(!formValid)
@@ -142,8 +138,24 @@ struct HostSetupView: View {
             Text("A dedicated Secure Enclave key for signing git commits. Next you'll register it on your git host as a **Signing Key** and configure git — Touch ID on each commit, no on-disk key to steal.")
                 .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
             Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
+                GridRow {
+                    Text("Provider").foregroundStyle(.secondary).gridColumnAlignment(.trailing)
+                    Picker("Provider", selection: $provider) {
+                        Text("GitHub").tag(HostSetup.GitProvider.github)
+                        Text("GitLab").tag(HostSetup.GitProvider.gitlab)
+                        Text("Bitbucket").tag(HostSetup.GitProvider.bitbucket)
+                        Text("Codeberg").tag(HostSetup.GitProvider.codeberg)
+                        Text("Other…").tag(HostSetup.GitProvider.other)
+                    }
+                    .labelsHidden().frame(maxWidth: 200, alignment: .leading)
+                }
+                if provider == .other {
+                    field("Host", "git.example.com", $customHost)
+                }
                 field("Key name", "commit-signing", $keyName)
             }
+            Text("The provider is used to deep-link to its signing-key page and to verify locally. Signing works even without one.")
+                .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
             Toggle("Touch ID only (currently enrolled fingerprints)", isOn: $touchIDOnly)
                 .toggleStyle(.checkbox).font(.callout)
         }
@@ -176,7 +188,7 @@ struct HostSetupView: View {
             commandBox(gen.pubLine)
             HStack {
                 Spacer()
-                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+                Button("Done") { resetForm() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
             }
         }
     }
@@ -228,11 +240,13 @@ struct HostSetupView: View {
         case .git: setUpGit(); return
         case .sign:
             guard let name = createKeyForName() else { return }
+            // A key created via Sign-commits is dedicated to signing — harden it to git-only
+            // by default (the signing-side analog of pinning; reversible on the next page).
+            state.setGitSigningOnly(true, name: name)
+            let host = providerHost()
             state.signingSetupKey = name
-            state.signingSetupHost = nil
-            dismiss()
-            NSApp.activate(ignoringOtherApps: true)
-            openWindow(id: SigningSetupView.windowID)
+            state.signingSetupHost = host.isEmpty ? nil : host
+            state.configDetail = .signing
             return
         case .bare:
             if createKeyForName() != nil { bareResult = state.lastGenerated }
@@ -259,9 +273,7 @@ struct HostSetupView: View {
         }
         error = nil
         state.migrateAlias = a
-        dismiss()
-        NSApp.activate(ignoringOtherApps: true)
-        openWindow(id: MigrateHostView.windowID)
+        state.configDetail = .migrateHost
     }
 
     // MARK: Result
@@ -290,9 +302,16 @@ struct HostSetupView: View {
 
             HStack {
                 Spacer()
-                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+                Button("Done") { resetForm() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
             }
         }
+    }
+
+    /// Return to a blank form after a completed server/bare setup (this is a tab now, not a
+    /// window that closes).
+    private func resetForm() {
+        result = nil; bareResult = nil
+        error = nil; pinMessage = nil; pinned = false; copied = false
     }
 
     private func pin(_ r: AppState.HostSetupResult) {

--- a/Sources/FobApp/KeysView.swift
+++ b/Sources/FobApp/KeysView.swift
@@ -1,0 +1,179 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The Keys page: full per-key management (the roomy counterpart to the popover's ••• menu).
+/// Each row is tailored to what the key is actually for — a signing-only key doesn't offer
+/// "Sign commits…" or "Pin" (it does no SSH auth); an auth key offers pin + a signing hop.
+/// Actions reuse AppState, so they take effect immediately and mirror what the CLI writes.
+struct KeysView: View {
+    @EnvironmentObject var state: AppState
+
+    @State private var usage: [String: AppState.KeyUsage] = [:]
+    @State private var pruneError: String?
+
+    private static let reuseChoices: [(Int, String)] =
+        [(0, "Touch every time"), (30, "Reuse 30s"), (60, "Reuse 1m"), (300, "Reuse 5m")]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Keys").font(.title2.weight(.semibold))
+                Spacer()
+                Button("New key…") { state.openConfig(tab: .newKey) }
+            }
+
+            if let pruneError {
+                Label(pruneError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
+            }
+
+            if state.keys.isEmpty {
+                Text("No keys yet. Create one from the **New key** tab.")
+                    .font(.callout).foregroundStyle(.secondary).padding(.vertical, 20)
+            } else {
+                ScrollView {
+                    VStack(spacing: 8) {
+                        ForEach(state.keys) { key in row(key) }
+                    }
+                }
+                .frame(minHeight: 220, maxHeight: 440)
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear(perform: loadUsage)
+        .onChange(of: state.configRevision) { _ in loadUsage() }
+        .onChange(of: state.keys.count) { _ in loadUsage() }
+    }
+
+    private func loadUsage() {
+        usage = state.keyUsages()
+    }
+
+    private func row(_ key: KeyInfo) -> some View {
+        let use = usage[key.name]
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text(key.name).font(.callout.weight(.semibold))
+                ForEach(roleBadges(use), id: \.self) { badge($0) }
+            }
+            Text(meta(key, use)).font(.caption).foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                // Pin is SSH-auth only — hide it for a signing-only key (but always allow
+                // Unpin if something is pinned).
+                if key.isPinned {
+                    Button("Unpin") { state.unpin(name: key.name) }
+                } else if !(use?.isSigningOnly ?? false) {
+                    Button("Pin…") { state.requestPin(name: key.name) }
+                }
+
+                Menu(reuseLabel(key.reuseSeconds)) {
+                    ForEach(Self.reuseChoices, id: \.0) { seconds, label in
+                        Button {
+                            state.setReuse(name: key.name, seconds: seconds)
+                        } label: {
+                            if key.reuseSeconds == seconds { Label(label, systemImage: "checkmark") }
+                            else { Text(label) }
+                        }
+                    }
+                }
+                .frame(width: 150)
+
+                // Signing is a git concept: manage it if already signing; offer it for a
+                // git-service or bare key; omit it for a plain server-login key.
+                if use?.signsCommits ?? false {
+                    Button("Signing setup…") { openSigning(key.name) }
+                        .help("Review or change this key's commit-signing configuration.")
+                } else if use?.canOfferSigning ?? true {
+                    Button("Sign commits…") { openSigning(key.name) }
+                }
+
+                Spacer()
+                Button(role: .destructive) { state.requestDelete(name: key.name) } label: {
+                    Text("Delete").foregroundStyle(Theme.red)
+                }
+            }
+            .font(.caption)
+
+            // A signing key that also carries an SSH host alias — offer to prune it, since a
+            // signing key doesn't need one (signing goes through the fob-sign wrapper). Opt-in,
+            // because a key CAN be genuinely dual-purpose (e.g. GitLab allows one for both).
+            if let use, use.signsCommits, !use.authHosts.isEmpty {
+                ForEach(use.authHosts, id: \.self) { alias in
+                    HStack(spacing: 6) {
+                        Image(systemName: "info.circle").foregroundStyle(.secondary)
+                        Text("Also an SSH alias “\(alias)” — a signing key usually doesn't need one.")
+                            .foregroundStyle(.secondary)
+                        Button("Remove alias") { prune(alias) }
+                    }
+                    .font(.caption2)
+                }
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+    }
+
+    private func openSigning(_ name: String) {
+        state.signingSetupKey = name
+        state.signingSetupHost = nil
+        state.configDetail = .signing
+    }
+
+    private func prune(_ alias: String) {
+        pruneError = state.removeSSHHostAlias(alias)
+        loadUsage()
+    }
+
+    /// Short role tags shown next to the key name.
+    private func roleBadges(_ use: AppState.KeyUsage?) -> [String] {
+        guard let use else { return [] }
+        var tags: [String] = []
+        if use.signsCommits { tags.append("Signing") }
+        if !use.authHosts.isEmpty { tags.append("Auth") }
+        if use.isUnused { tags.append("Unused") }
+        return tags
+    }
+
+    private func badge(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 9, weight: .bold)).tracking(0.4)
+            .padding(.horizontal, 5).padding(.vertical, 1.5)
+            .background(RoundedRectangle(cornerRadius: 4).fill(badgeColor(text).opacity(0.16)))
+            .foregroundStyle(badgeColor(text))
+    }
+
+    private func badgeColor(_ text: String) -> Color {
+        switch text {
+        case "Signing": return Theme.accent
+        case "Auth": return Theme.green
+        default: return .secondary
+        }
+    }
+
+    /// Second line: what the key is used for, then its pin/reuse state.
+    private func meta(_ key: KeyInfo, _ use: AppState.KeyUsage?) -> String {
+        var parts: [String] = []
+        if let use {
+            if !use.authHosts.isEmpty { parts.append("auth: \(use.authHosts.joined(separator: ", "))") }
+            if use.signsCommits { parts.append("commit signing") }
+            if use.isUnused { parts.append("not yet used") }
+        }
+        parts.append(key.pinnedNames.isEmpty ? "any destination" : "pinned → \(key.pinnedNames.joined(separator: ", "))")
+        parts.append(reuseLabel(key.reuseSeconds).lowercased())
+        return parts.joined(separator: " · ")
+    }
+
+    private func reuseLabel(_ seconds: Int) -> String {
+        switch seconds {
+        case 0: return "Touch every time"
+        case 60: return "Reuse 1m"
+        case 300: return "Reuse 5m"
+        default: return "Reuse \(seconds)s"
+        }
+    }
+}

--- a/Sources/FobApp/MigrateHostView.swift
+++ b/Sources/FobApp/MigrateHostView.swift
@@ -2,17 +2,14 @@ import AppKit
 import FobKit
 import SwiftUI
 
-/// The per-host migration flow (opened from MigrateView). Staged, and safe by design:
+/// The per-host migration page (a pushed detail from the Migrate tab / a checkup finding).
+/// Staged, and safe by design:
 /// install the fob key on the server (using your existing key) → preview + back up +
 /// apply the ~/.ssh/config edit → verify fob works with Touch ID → pin, and only then
 /// optionally retire the old key. The old key stays active until Retire, so there's no
 /// lockout at any step.
 struct MigrateHostView: View {
-    static let windowID = "fob-migrate-host"
-
     @EnvironmentObject var state: AppState
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.openWindow) private var openWindow
 
     @State private var candidate: AppState.MigrationCandidate?
     @State private var alreadyMigrated = false
@@ -51,7 +48,7 @@ struct MigrateHostView: View {
             else { Text("This host is no longer in ~/.ssh/config.").foregroundStyle(.secondary) }
         }
         .padding(22)
-        .frame(width: 520)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear(perform: load)
         .onChange(of: state.migrateAlias) { _ in load() }
     }
@@ -80,7 +77,7 @@ struct MigrateHostView: View {
         }
         HStack {
             Spacer()
-            Button("Done") { dismiss() }.keyboardShortcut(.defaultAction)
+            Button("Done") { state.configDetail = nil }.keyboardShortcut(.defaultAction)
         }
     }
 
@@ -177,8 +174,7 @@ struct MigrateHostView: View {
                 Button("Sign commits with this key →") {
                     state.signingSetupKey = alias
                     state.signingSetupHost = c.host
-                    NSApp.activate(ignoringOtherApps: true)
-                    openWindow(id: SigningSetupView.windowID)
+                    state.configDetail = .signing
                 }
             }
         }

--- a/Sources/FobApp/MigrateView.swift
+++ b/Sources/FobApp/MigrateView.swift
@@ -1,16 +1,11 @@
-import AppKit
 import FobKit
 import SwiftUI
 
-/// The "Migrate to fob" window: lists the servers already in ~/.ssh/config and starts a
+/// The "Migrate to fob" page: lists the servers already in ~/.ssh/config and starts a
 /// per-host migration. Servers are the focus; commit signing is surfaced only as a
 /// pointer to the ••• → "Use for commit signing…" flow.
 struct MigrateView: View {
-    static let windowID = "fob-migrate"
-
     @EnvironmentObject var state: AppState
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.openWindow) private var openWindow
 
     @State private var servers: [AppState.MigrationCandidate] = []
     @State private var signing: GitConfig.SigningInfo?
@@ -45,11 +40,10 @@ struct MigrateView: View {
             HStack {
                 Button("Refresh") { load() }
                 Spacer()
-                Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
             }
         }
         .padding(22)
-        .frame(width: 480)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear(perform: load)
         .onChange(of: state.configRevision) { _ in load() }
     }
@@ -93,8 +87,7 @@ struct MigrateView: View {
 
     private func openMigrate(_ alias: String) {
         state.migrateAlias = alias
-        NSApp.activate(ignoringOtherApps: true)
-        openWindow(id: MigrateHostView.windowID)
+        state.configDetail = .migrateHost
     }
 
     @ViewBuilder

--- a/Sources/FobApp/SettingsView.swift
+++ b/Sources/FobApp/SettingsView.swift
@@ -1,0 +1,42 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The Settings page: app-level preferences that used to live in the popover footer.
+struct SettingsView: View {
+    @EnvironmentObject var state: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Settings").font(.title2.weight(.semibold))
+            }
+
+            Toggle(isOn: Binding(get: { state.launchAtLogin },
+                                 set: { state.setLaunchAtLogin($0) })) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Launch fob at login").font(.callout)
+                    Text("Keep the agent running so `ssh` always reaches fob. Recommended.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            .toggleStyle(.checkbox)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("AGENT SOCKET").font(.caption.weight(.semibold)).foregroundStyle(.secondary).tracking(0.6)
+                Text(state.socketPath)
+                    .font(.system(.caption, design: .monospaced)).textSelection(.enabled)
+                    .foregroundStyle(.secondary)
+                Text("Point ssh at this in `~/.ssh/config` with `IdentityAgent`.")
+                    .font(.caption).foregroundStyle(.tertiary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -2,17 +2,14 @@ import AppKit
 import FobKit
 import SwiftUI
 
-/// The "Commit signing" window (opened from a key's ••• menu). Sets a fob key up for
+/// The "Commit signing" page (a pushed detail in the Configure window). Sets a fob key up for
 /// Touch ID-gated git commit signing: shows the public key to register on your git
 /// host and the git config (per-repo or global, with a one-click apply for global).
 /// Signing is routed to fob via a `gpg.ssh.program` wrapper, so it never touches
 /// SSH_AUTH_SOCK — other ssh agents and `git push` auth are unaffected. The one thing
 /// it does directly is the namespace restriction — fob's own policy.
 struct SigningSetupView: View {
-    static let windowID = "fob-signing-setup"
-
     @EnvironmentObject var state: AppState
-    @Environment(\.dismiss) private var dismiss
 
     @State private var info: AppState.SigningInfo?
     @State private var gitOnly = false
@@ -34,7 +31,7 @@ struct SigningSetupView: View {
             if let info { content(info) } else { Text("Key unavailable.").foregroundStyle(.secondary) }
         }
         .padding(22)
-        .frame(width: 500)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { load() }
         .onChange(of: state.signingSetupKey) { _ in load() }
     }
@@ -60,10 +57,14 @@ struct SigningSetupView: View {
         Text("Sign git commits with “\(keyName)” — Touch ID on each commit, and your host (GitHub, GitLab, …) shows *Verified*.")
             .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
 
-        Toggle(isOn: Binding(get: { gitOnly }, set: { gitOnly = $0; state.setGitSigningOnly($0, name: keyName) })) {
-            Text("Restrict this key to git commits only").font(.callout)
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle(isOn: Binding(get: { gitOnly }, set: { gitOnly = $0; state.setGitSigningOnly($0, name: keyName) })) {
+                Text("Only let this key sign git commits").font(.callout)
+            }
+            .toggleStyle(.checkbox)
+            Text("Rejects other SSHSIG signatures (e.g. `ssh-keygen -Y sign` in another namespace). Doesn't affect SSH login — that's governed by pinning.")
+                .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
         }
-        .toggleStyle(.checkbox)
 
         step(1, "Register the public key on your git host as a Signing Key",
              "Key type: **Signing Key** — a separate entry from an Authentication key (GitHub keeps the two apart; on GitLab one key can be marked for both).")
@@ -116,7 +117,7 @@ struct SigningSetupView: View {
 
         HStack {
             Spacer()
-            Button("Done") { dismiss() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+            Button("Done") { state.configDetail = nil }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
         }
     }
 

--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -430,4 +430,44 @@ public enum HostSetup {
         try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: configURL.path)
         return backupURL
     }
+
+    /// Remove a fob-created `Host <alias>` block entirely — used when its key is deleted, so
+    /// a dead entry pointing at a now-missing key doesn't linger (and re-appear in Migrate).
+    /// Only removes when the block is a single-alias block that routes through fob AND has no
+    /// active non-fob `IdentityFile` (a migrated host with a live old key is left untouched).
+    /// Also drops an immediately preceding `# added by fob` comment and trailing blank lines.
+    /// Returns nil when there's nothing safe to remove.
+    public static func removeFobHostBlock(_ config: String, alias: String) -> String? {
+        guard let parsed = parseHostBlock(alias: alias, in: config), parsed.usesFobAgent,
+              parsed.identityFiles.allSatisfy({ isFobIdentity($0) }) else { return nil }
+        var lines = config.components(separatedBy: "\n")
+        func isSectionStart(_ raw: String) -> Bool {
+            let l = raw.trimmingCharacters(in: .whitespaces).lowercased()
+            return l == "host" || l.hasPrefix("host ") || l == "match" || l.hasPrefix("match ")
+        }
+        // The literal `Host <alias>` line — only a single-alias block is safe to remove
+        // wholesale (a `Host a b` line also serves other aliases).
+        var start: Int?
+        for (i, raw) in lines.enumerated() {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            guard line.lowercased().hasPrefix("host ") else { continue }
+            let tokens = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).dropFirst().map(String.init)
+            if tokens == [alias] { start = i; break }
+        }
+        guard var blockStart = start else { return nil }
+        var end = blockStart + 1
+        while end < lines.count { if isSectionStart(lines[end]) { break }; end += 1 }
+        // Absorb an immediately preceding fob-written marker ("# added by fob[ setup]") only —
+        // never an unrelated user comment sitting above the block.
+        if blockStart > 0,
+           lines[blockStart - 1].trimmingCharacters(in: .whitespaces).hasPrefix("# added by fob") {
+            blockStart -= 1
+        }
+        // Absorb trailing blank lines that separated this block from the next.
+        while end < lines.count, lines[end].trimmingCharacters(in: .whitespaces).isEmpty { end += 1 }
+        lines.removeSubrange(blockStart..<end)
+        var result = lines.joined(separator: "\n")
+        if !result.isEmpty && !result.hasSuffix("\n") { result += "\n" }
+        return result
+    }
 }

--- a/Tests/FobKitTests/MigrationTests.swift
+++ b/Tests/FobKitTests/MigrationTests.swift
@@ -151,6 +151,35 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(migrate(retired, retireOld: true)!, retired, "retire is idempotent")
     }
 
+    // 12c. removeFobHostBlock deletes a pure fob-created block (+ its "# added by fob"
+    //      comment) but leaves a migrated host with a live old key untouched.
+    func testRemoveFobHostBlock() {
+        let config = """
+        Host keep
+          IdentityFile ~/.ssh/id_keep
+
+        # added by fob
+        Host web
+          HostName web.example
+          IdentityAgent ~/.fob/agent.sock
+          IdentityFile ~/.ssh/fob_web.pub
+          IdentitiesOnly yes
+
+        Host other
+          HostName other.example
+        """
+        let out = HostSetup.removeFobHostBlock(config, alias: "web")!
+        XCTAssertFalse(out.contains("Host web"))
+        XCTAssertFalse(out.contains("# added by fob"))
+        XCTAssertTrue(out.contains("Host keep"))
+        XCTAssertTrue(out.contains("Host other"))
+        // A block with an ACTIVE non-fob IdentityFile (migrated, old key live) is left alone.
+        let migrated = "Host web\n  IdentityAgent ~/.fob/agent.sock\n  IdentityFile ~/.ssh/fob_web.pub\n  IdentityFile ~/.ssh/id_old\n"
+        XCTAssertNil(HostSetup.removeFobHostBlock(migrated, alias: "web"))
+        // No such block → nil.
+        XCTAssertNil(HostSetup.removeFobHostBlock("Host a\n  HostName a\n", alias: "web"))
+    }
+
     // 13. Alias only under Host * / Match → nil (never touched).
     func testWildcardAndMatchNotMigrated() {
         XCTAssertNil(migrate("Host *\n  IdentityFile ~/.ssh/id\n"))


### PR DESCRIPTION
### Why

The menu-bar app spawned five separate top-level windows (New key, Migrate, Migrate-a-server, Commit signing, SSH checkup). They stacked up, had no "back", and frequently opened on the wrong Space. The popover had become a launcher for window sprawl.

This replaces them with one window driven by segmented tabs, and trims the popover back to what a menu-bar app is good at — a glance surface plus a single Configure… button.

### What changed

**Window & routing**
- New ConfigWindow with tabs: New key · Keys · Migrate · Checkup · Audit · Settings.
- Commit-signing and Migrate-a-host aren't tabs — they're reached from other flows, so they render as a pushed detail with a Back button.
- AppState gains configTab/configDetail + openConfig(); every former openWindow(id:) hop is now an in-window route change. The five Window scenes collapse to one; the five flow views became embeddable pages (dismiss/openWindow swapped for router mutations, fixed widths relaxed).

Popover — New key / Migrate / SSH-checkup / Reveal-audit buttons collapse into one Configure…; Launch-at-login moves to the Settings tab. Visuals otherwise unchanged.

**New pages**
- Keys — role-aware per-key management (badges Signing / Auth / Unused). Pin is hidden for a signing-only key; commit signing is offered only for git-service or bare keys (not plain server logins), and shows "Signing setup…" when the key already signs. Offers to prune a redundant SSH host alias on a signing key.
- Audit — in-app hash-chain log with a chain-integrity badge (reuses AuditLog.entries/firstBrokenLink) + Verify / Reveal in Finder.
- Settings — Launch-at-login + the agent socket path.

**Also**
- New key → Sign commits gains a provider dropdown (deep-links to the signing-key page) and hardens the new key to git-only by default.
- Deleting a key now removes its exported .pub and fob-created Host block (backup first; a migrated host with a live old key is left untouched), so a deleted key stops re-appearing in Migrate. Guarded on a successful erase.
- keyUsage computed in one batched pass (shared git/ssh reads) to fix Keys-tab open lag.

**Testing**

- swift build clean (no warnings); 89 swift test cases pass (added testRemoveFobHostBlock, plus retire/keychain coverage).
- Built + installed the app and drove every tab and hop end-to-end on a real multi-account machine: signing/migrate/checkup route in-window, delete cleans up config, Keys roles read correctly, Audit shows the chain badge, Settings toggles the login item.
- Self-review pass fixed a split doc comment, unconditional-cleanup-on-failed-delete, and over-broad ssh-config comment absorption.

**Notes**

- No new dependencies; UI/IA only — all creation/migration/signing/checkup logic is reused unchanged.
- Follow-ups (not in scope): auto-hardening existing signing-only keys to git-only (needs a "policy explicitly set" marker to avoid fighting the user), and offloading the audit parse for very large logs.