### PR TITLE
CI: auto-build & draft a notarized release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,20 @@
 name: release
 
-# Builds, signs (Developer ID), notarizes, and publishes fob.app.
+# Builds, signs (Developer ID), notarizes, staples, and attaches fob.app to a GitHub
+# release — automatically on a `v*` tag push (also runnable manually from the Actions tab).
 #
-# MANUAL-ONLY (run it from the Actions tab). It is intentionally NOT triggered by tag
-# pushes: releases are currently cut locally with Scripts/release.sh, and the CI path
-# first needs these repo secrets configured — DEVELOPER_ID_CERT_P12,
-# DEVELOPER_ID_CERT_PASSWORD, KEYCHAIN_PASSWORD, AC_API_KEY_P8, AC_API_KEY_ID,
-# AC_API_ISSUER_ID. To enable fully-automated tag releases later, add those secrets
-# and restore the `push: { tags: ["v*"] }` trigger.
+# Requires these repo secrets (Settings → Secrets and variables → Actions):
+#   DEVELOPER_ID_CERT_P12, DEVELOPER_ID_CERT_PASSWORD, KEYCHAIN_PASSWORD,
+#   AC_API_KEY_P8, AC_API_KEY_ID, AC_API_ISSUER_ID  (+ optional DEVELOPER_ID_IDENTITY).
+# See docs/RELEASING.md. Until they're set, the run fails at the signing step.
+#
+# What CI does NOT do (on purpose): it publishes a DRAFT so you review the notes and
+# choose when it goes live, and it does not bump the Homebrew tap — the tap commit is
+# kept fob-signed, which needs the Secure Enclave (unavailable in CI). Bump the tap
+# locally with the sha256 this run reports (shown in the job summary).
 on:
+  push:
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:
@@ -58,15 +64,28 @@ jobs:
           AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
         run: ./Scripts/release.sh
 
-      - name: Publish GitHub release
+      # Draft so you review the auto-generated notes and publish when ready. The
+      # notarized zip is already attached, so there's no manual artifact upload.
+      - name: Draft GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
             "${{ steps.build.outputs.zip }}" \
-            --title "$GITHUB_REF_NAME" --generate-notes
+            --title "$GITHUB_REF_NAME" --generate-notes --draft
 
-      # The cask lives in your tap repo (olivierzol/homebrew-fob). Bump it with these:
-      - name: Cask bump values
+      # The cask lives in the tap repo (olivierzol/homebrew-fob) and its commit is
+      # fob-signed, so bump it locally with the values below — not from CI.
+      - name: Tap-bump instructions
         run: |
-          echo "::notice::Update Casks/fob.rb in your tap to version ${{ steps.build.outputs.version }}, sha256 ${{ steps.build.outputs.sha256 }}"
+          {
+            echo "### fob ${{ steps.build.outputs.version }} — release drafted ✅"
+            echo ""
+            echo "1. Review the **draft** release's notes and **Publish** it."
+            echo "2. Bump the tap cask (\`Casks/fob.rb\`) locally, then push a fob-signed commit:"
+            echo ""
+            echo '```'
+            echo "version \"${{ steps.build.outputs.version }}\""
+            echo "sha256  \"${{ steps.build.outputs.sha256 }}\""
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,16 +51,30 @@ Replace `olivierzol` in the cask (three places) with your GitHub account/org.
 
 ## Cutting a release
 
+Once the secrets above are set, a tag push does the heavy lifting in CI:
+
 1. Bump `VERSION` / `BUILD_NUMBER` in `Scripts/build-app.sh`.
-2. Tag and push:
+2. Commit and push a **signed** release commit + tag:
    ```sh
-   git tag v0.3.0
-   git push origin v0.3.0
+   git commit -am "Release v0.3.0"
+   git tag -s v0.3.0 -m "fob v0.3.0"
+   git push origin main v0.3.0
    ```
-3. The `release` workflow builds, signs, notarizes, staples, and attaches
-   `fob-<version>.zip` to a GitHub release. It prints the new `version` and
-   `sha256` as a workflow notice.
-4. Update `version` and `sha256` in your tap's `Casks/fob.rb` and commit.
+3. The tag push triggers the `release` workflow: it builds, signs, notarizes,
+   staples, and attaches `fob-<version>.zip` to a **draft** GitHub release. The
+   job summary shows the `version` and `sha256`. Review the auto-generated notes
+   and **Publish** the release.
+4. Bump `version` + `sha256` (use the sha256 from step 3 — notarization changes
+   the zip, so it differs from any local build) in your tap's `Casks/fob.rb` and
+   push a **fob-signed** commit. The tap bump stays local because its commit is
+   signed with the Secure Enclave key, which CI can't reach.
+
+> CI publishes a **draft** (not live) and does **not** touch the tap — so the
+> release only goes public when you publish it, and the tap commit stays signed.
+> To make CI auto-publish instead, drop `--draft` from the workflow's release step.
+
+Prefer to cut it entirely locally? The [local flow](#building-a-signed-release-locally)
+below still works and is the fallback if CI is unavailable.
 
 ## Building a signed release locally
 


### PR DESCRIPTION
Activates the existing `release.yml` (it was `workflow_dispatch`-only with the tag trigger commented out) so cutting a release stops being a manual local chore.

## What changes
- **Tag trigger on** — pushing a `v*` tag runs build → sign → notarize → staple → attach-artifact in CI (kept `workflow_dispatch` too).
- **Draft release** — the notarized zip is attached automatically; you review the auto-generated notes and click **Publish**. Removes the ~5-min local notarize wait *and* the web upload from the wrong gh account.
- **Job summary** reports the version + the notarized zip's sha256 to paste into the tap.
- `docs/RELEASING.md` updated to the activated flow.

## Intentionally NOT automated
The Homebrew **tap bump** stays a local, fob-signed step — its commit is signed with the Secure Enclave key, which CI can't reach. Use the sha256 from the job summary (notarization changes the zip, so it differs from any local build).

## Before the first CI release
Repo secrets must be set (currently none are): `DEVELOPER_ID_CERT_P12`, `DEVELOPER_ID_CERT_PASSWORD`, `KEYCHAIN_PASSWORD`, `AC_API_KEY_P8`, `AC_API_KEY_ID`, `AC_API_ISSUER_ID` (+ optional `DEVELOPER_ID_IDENTITY`). See `docs/RELEASING.md`. Until set, the run fails at the signing step.