### PR TITLE
Auto-harden signing-only keys + prune stale allowed_signers

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -164,6 +164,14 @@ final class AppState: ObservableObject {
             _ = try? HostSetup.backupAndWriteConfig(new, at: sshConfigURL)
             configRevision += 1
         }
+        // Drop this key's own allowed_signers line (fob-commented only; hand-added entries
+        // are untouched) so a deleted signing key doesn't leave a stale, unverifiable entry.
+        let signers = ssh.appendingPathComponent("allowed_signers")
+        if let text = try? String(contentsOf: signers, encoding: .utf8),
+           let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) {
+            try? Data(pruned.utf8).write(to: signers, options: .atomic)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signers.path)
+        }
     }
 
     /// Remove a single fob `Host <alias>` block from ~/.ssh/config (backup first) — used by
@@ -749,6 +757,16 @@ final class AppState: ObservableObject {
             findings.append(f)
         }
 
+        // 5. allowed_signers entries fob wrote for keys that no longer exist.
+        let liveNames = Set(((try? store?.all()) ?? []).map(\.name))
+        let signersURL = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ssh/allowed_signers")
+        let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
+        let orphans = SSHCheckup.AllowedSigners.orphanedFobNames(signersText, liveNames: liveNames)
+        if let f = SSHCheckup.allowedSignersOrphanFinding(orphans: orphans) {
+            findings.append(f)
+        }
+
         return CheckupReport(findings: findings.sorted { $0.severity < $1.severity })
     }
 
@@ -872,12 +890,30 @@ final class AppState: ObservableObject {
     }
 
     /// Restrict a key to git-commit signatures only (["git"]), or clear the restriction.
-    func setGitSigningOnly(_ on: Bool, name: String) {
+    /// Restrict (or clear) a key's SSHSIG signing to the git namespace. `explicit` marks it
+    /// as a deliberate user choice (the toggle), which stops the signing page from ever
+    /// auto-hardening it again; auto-harden passes `explicit: false`.
+    func setGitSigningOnly(_ on: Bool, name: String, explicit: Bool = true) {
         run { store in
             var policy = store.policy(name: name)
             policy.allowedNamespaces = on ? ["git"] : nil
+            if explicit { policy.namespaceChoiceMade = true }
             try store.savePolicy(policy, name: name)
         }
+    }
+
+    /// Secure default for the signing page: harden a dedicated signing key (no SSH-auth role)
+    /// to git-only the first time its signing config is opened, unless the user has already
+    /// made an explicit namespace choice. Returns the resulting git-only state for the toggle.
+    func autoHardenSigningIfEligible(name: String) -> Bool {
+        guard let store else { return false }
+        let policy = store.policy(name: name)
+        let signingOnly = keyUsage(name: name).authHosts.isEmpty
+        if policy.shouldAutoHardenSigning(isSigningOnly: signingOnly) {
+            setGitSigningOnly(true, name: name, explicit: false)
+            return true
+        }
+        return policy.allowedNamespaces == ["git"]
     }
 
 

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -38,7 +38,9 @@ struct SigningSetupView: View {
 
     private func load() {
         info = state.signingInfo(for: keyName)
-        gitOnly = info?.gitOnly ?? false
+        // Auto-harden a dedicated signing key to git-only on first open (never overriding a
+        // deliberate un-tick — see KeyPolicy.namespaceChoiceMade).
+        gitOnly = state.autoHardenSigningIfEligible(name: keyName)
         identities = state.discoverGitIdentities()
         // Multi-account: default to the first identity (writing --global would clobber
         // their setup). Single-account: default to per-repo (safe, universal).

--- a/Sources/FobKit/KeyPolicy.swift
+++ b/Sources/FobKit/KeyPolicy.swift
@@ -19,8 +19,17 @@ public struct KeyPolicy: Codable {
     /// Does not affect SSH authentication, which is governed by `pinnedHostKeys`.
     public var allowedNamespaces: [String]?
 
+    /// Set once the user has *explicitly* chosen this key's namespace restriction (ticked or
+    /// unticked "only sign git commits"). It stops the signing page from re-hardening a key
+    /// whose restriction the user deliberately cleared — `nil` allowedNamespaces alone can't
+    /// tell "never decided" from "chose unrestricted". Optional (nil = never chosen) so old
+    /// `.policy` JSON that predates this field still decodes (synthesized Codable requires a
+    /// key for non-optional properties even when they have a default).
+    public var namespaceChoiceMade: Bool?
+
     public var isDefault: Bool {
-        pinnedHostKeys.isEmpty && (reuseSeconds ?? 0) <= 0 && allowedNamespaces == nil
+        pinnedHostKeys.isEmpty && (reuseSeconds ?? 0) <= 0
+            && allowedNamespaces == nil && namespaceChoiceMade != true
     }
 
     /// Whether an SSHSIG signature for `namespace` is permitted by this policy.
@@ -29,11 +38,19 @@ public struct KeyPolicy: Codable {
         return allowedNamespaces.contains(namespace)
     }
 
+    /// Whether the signing page should auto-harden this key to git-only: only when it's a
+    /// dedicated signing key (no SSH-auth role), currently unrestricted, and the user hasn't
+    /// made an explicit namespace choice yet. Never overrides a deliberate user decision.
+    public func shouldAutoHardenSigning(isSigningOnly: Bool) -> Bool {
+        isSigningOnly && allowedNamespaces == nil && namespaceChoiceMade != true
+    }
+
     public init(pinnedHostKeys: [Data] = [], reuseSeconds: Double? = nil,
-                allowedNamespaces: [String]? = nil) {
+                allowedNamespaces: [String]? = nil, namespaceChoiceMade: Bool? = nil) {
         self.pinnedHostKeys = pinnedHostKeys
         self.reuseSeconds = reuseSeconds
         self.allowedNamespaces = allowedNamespaces
+        self.namespaceChoiceMade = namespaceChoiceMade
     }
 }
 

--- a/Sources/FobKit/SSHCheckup.swift
+++ b/Sources/FobKit/SSHCheckup.swift
@@ -161,6 +161,51 @@ public enum SSHCheckup {
             let sep = fileText.isEmpty || fileText.hasSuffix("\n") ? "" : "\n"
             return fileText + sep + entry(email: email, pubLine: pubLine) + "\n"
         }
+
+        /// The fob key name from a full allowed_signers LINE's trailing `fob:<name>` comment,
+        /// if any (the line ends with the pubLine, whose comment we already know how to read).
+        static func fobKeyName(fromLine line: String) -> String? {
+            guard let comment = line.split(separator: " ").last, comment.hasPrefix("fob:") else { return nil }
+            return String(comment.dropFirst(4))
+        }
+
+        /// Drop the allowed_signers line(s) for a given fob key (matched by the trailing
+        /// `fob:<name>` comment). Only ever touches fob's own entries — hand-added lines
+        /// (email-commented ed25519 keys, etc.) are left untouched. nil = nothing changed.
+        public static func removing(_ fileText: String, fobKeyName name: String) -> String? {
+            let lines = fileText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            let kept = lines.filter { fobKeyName(fromLine: $0) != name }
+            guard kept.count != lines.count else { return nil }
+            let joined = kept.joined(separator: "\n")
+            // Preserve a trailing newline only if there's content (avoid a lone "\n").
+            let trimmed = joined.hasSuffix("\n") ? String(joined.dropLast()) : joined
+            return trimmed.isEmpty ? "" : trimmed + "\n"
+        }
+
+        /// fob key names present in allowed_signers (via `fob:<name>` comments) that are NOT
+        /// in `liveNames` — i.e. entries left behind for keys that no longer exist.
+        public static func orphanedFobNames(_ fileText: String, liveNames: Set<String>) -> [String] {
+            var seen = Set<String>(), out: [String] = []
+            for line in fileText.split(separator: "\n") {
+                guard let name = fobKeyName(fromLine: String(line)), !liveNames.contains(name),
+                      !seen.contains(name) else { continue }
+                seen.insert(name); out.append(name)
+            }
+            return out
+        }
+    }
+
+    /// Flag `~/.ssh/allowed_signers` entries fob wrote for keys that no longer exist (e.g. a
+    /// signing key deleted before this cleanup shipped). Only fob-commented lines are counted;
+    /// nil = none.
+    public static func allowedSignersOrphanFinding(orphans: [String]) -> Finding? {
+        guard !orphans.isEmpty else { return nil }
+        let names = orphans.map { "“\($0)”" }.joined(separator: ", ")
+        let s = orphans.count == 1 ? "entry" : "entries"
+        return Finding(severity: .low, category: "Config",
+            title: "Stale allowed_signers \(s) for \(orphans.count == 1 ? "a deleted key" : "deleted keys")",
+            detail: "~/.ssh/allowed_signers still lists \(orphans.count) fob \(s) (\(names)) whose key fob no longer holds. Harmless, but tidy: delete those \(s) — fob prunes them automatically when you delete a key from now on.",
+            fix: .revealFile((NSString(string: "~/.ssh/allowed_signers")).expandingTildeInPath))
     }
 
     /// Flag when fob-signed commits can't be verified LOCALLY (GitHub's Verified is

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -136,7 +136,7 @@ func sshAddListPublicKeys() -> String {
     return String(decoding: data, as: UTF8.self)
 }
 
-func sshCheckupFindings(fobKeyBlobs: Set<String>) -> [SSHCheckup.Finding] {
+func sshCheckupFindings(fobKeyBlobs: Set<String>, fobKeyNames: Set<String>) -> [SSHCheckup.Finding] {
     var findings: [SSHCheckup.Finding] = []
     let home = FileManager.default.homeDirectoryForCurrentUser
     let sshDir = home.appendingPathComponent(".ssh")
@@ -217,6 +217,14 @@ func sshCheckupFindings(fobKeyBlobs: Set<String>) -> [SSHCheckup.Finding] {
         findings.append(f)
     }
 
+    // allowed_signers entries fob wrote for keys that no longer exist.
+    let signersURL = home.appendingPathComponent(".ssh/allowed_signers")
+    let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
+    let orphans = SSHCheckup.AllowedSigners.orphanedFobNames(signersText, liveNames: fobKeyNames)
+    if let f = SSHCheckup.allowedSignersOrphanFinding(orphans: orphans) {
+        findings.append(f)
+    }
+
     return findings.sorted { $0.severity < $1.severity }
 }
 
@@ -289,7 +297,8 @@ do {
             let parts = line.split(separator: " ")
             return parts.count >= 2 ? String(parts[1]) : nil
         })
-        let findings = sshCheckupFindings(fobKeyBlobs: fobBlobs)
+        let fobNames = Set(((try? store.all()) ?? []).map(\.name))
+        let findings = sshCheckupFindings(fobKeyBlobs: fobBlobs, fobKeyNames: fobNames)
         if findings.isEmpty {
             print("✅ SSH checkup: no issues found — your ~/.ssh looks healthy.")
         } else {

--- a/Tests/FobKitTests/CheckupTests.swift
+++ b/Tests/FobKitTests/CheckupTests.swift
@@ -126,6 +126,33 @@ final class CheckupTests: XCTestCase {
         XCTAssertNil(SSHCheckup.AllowedSigners.appending(added!, email: "me@x.com", pubLine: pub)) // idempotent
     }
 
+    func testAllowedSignersRemovingAndOrphans() {
+        let file = """
+        me@x.com namespaces="git" ssh-ed25519 AAAA me@x.com
+        me@x.com namespaces="git" ecdsa-sha2-nistp256 BBBB fob:old
+        me@x.com namespaces="git" ecdsa-sha2-nistp256 CCCC fob:keep
+        """
+        // removing() drops only the matching fob line; the hand-added ed25519 + other fob line stay.
+        let pruned = SSHCheckup.AllowedSigners.removing(file, fobKeyName: "old")
+        XCTAssertNotNil(pruned)
+        XCTAssertFalse(pruned!.contains("fob:old"))
+        XCTAssertTrue(pruned!.contains("ssh-ed25519 AAAA me@x.com")) // hand-added untouched
+        XCTAssertTrue(pruned!.contains("fob:keep"))
+        // no such fob key → nil (nothing changed); never touches the email-commented line
+        XCTAssertNil(SSHCheckup.AllowedSigners.removing(file, fobKeyName: "me@x.com"))
+        XCTAssertNil(SSHCheckup.AllowedSigners.removing(file, fobKeyName: "absent"))
+        // orphans = fob names not in the live set (email lines are never counted).
+        XCTAssertEqual(SSHCheckup.AllowedSigners.orphanedFobNames(file, liveNames: ["keep"]), ["old"])
+        XCTAssertEqual(SSHCheckup.AllowedSigners.orphanedFobNames(file, liveNames: ["old", "keep"]), [])
+    }
+
+    func testAllowedSignersOrphanFinding() {
+        XCTAssertNil(SSHCheckup.allowedSignersOrphanFinding(orphans: []))
+        let f = SSHCheckup.allowedSignersOrphanFinding(orphans: ["old", "gone"])
+        XCTAssertEqual(f?.severity, .low)
+        XCTAssertTrue(f?.detail.contains("“old”") == true && f?.detail.contains("“gone”") == true)
+    }
+
     func testSigningVerificationFinding() {
         XCTAssertNil(SSHCheckup.signingVerificationFinding(usesFobSigning: false, allowedSignersConfigured: false, keyListed: false))
         XCTAssertTrue(SSHCheckup.signingVerificationFinding(usesFobSigning: true, allowedSignersConfigured: false, keyListed: false)?.title.contains("verifiable") == true)

--- a/Tests/FobKitTests/PolicyStoreTests.swift
+++ b/Tests/FobKitTests/PolicyStoreTests.swift
@@ -74,6 +74,46 @@ final class PolicyStoreTests: XCTestCase {
         XCTAssertNil(memory.storage["k"])
     }
 
+    // MARK: - KeyPolicy: namespaceChoiceMade marker (auto-harden)
+
+    func testPolicyDecodesOldJSONWithoutMarker() throws {
+        // A .policy written before the marker existed must still decode (marker defaults false).
+        let old = #"{"pinnedHostKeys":[],"allowedNamespaces":["git"]}"#
+        let policy = try JSONDecoder().decode(KeyPolicy.self, from: Data(old.utf8))
+        XCTAssertEqual(policy.allowedNamespaces, ["git"])
+        XCTAssertNotEqual(policy.namespaceChoiceMade, true)  // absent → treated as "not chosen"
+    }
+
+    func testIsDefaultAccountsForMarker() {
+        // An otherwise-empty policy that records a deliberate choice must NOT be "default"
+        // (else savePolicy would delete it and the choice would be forgotten → re-harden).
+        var p = KeyPolicy()
+        XCTAssertTrue(p.isDefault)
+        p.namespaceChoiceMade = true
+        XCTAssertFalse(p.isDefault)
+    }
+
+    func testShouldAutoHardenSigning() {
+        // Signing-only + unrestricted + no explicit choice → harden.
+        XCTAssertTrue(KeyPolicy().shouldAutoHardenSigning(isSigningOnly: true))
+        // Not signing-only (has an auth role) → never.
+        XCTAssertFalse(KeyPolicy().shouldAutoHardenSigning(isSigningOnly: false))
+        // Already restricted → nothing to do.
+        XCTAssertFalse(KeyPolicy(allowedNamespaces: ["git"]).shouldAutoHardenSigning(isSigningOnly: true))
+        // User made a choice (e.g. deliberately unrestricted) → don't override.
+        XCTAssertFalse(KeyPolicy(namespaceChoiceMade: true).shouldAutoHardenSigning(isSigningOnly: true))
+    }
+
+    func testMarkerSurvivesSaveLoadAndClearedPolicyPersists() throws {
+        let store = KeyStore(directory: URL(fileURLWithPath: "/tmp/unused"),
+                             policyStore: InMemoryPolicyStore())
+        // User unticks git-only on a signing-only key: allowedNamespaces nil BUT choice made.
+        try store.savePolicy(KeyPolicy(namespaceChoiceMade: true), name: "k")
+        // It must persist (not be dropped as "default") so it isn't re-hardened later.
+        XCTAssertEqual(store.policy(name: "k").namespaceChoiceMade, true)
+        XCTAssertFalse(store.policy(name: "k").shouldAutoHardenSigning(isSigningOnly: true))
+    }
+
     // MARK: - Keychain availability probe is safe on any build
 
     func testKeychainAvailabilityProbeDoesNotCrash() {


### PR DESCRIPTION
Two small key-hygiene fixes (plan PR A of the key-lifecycle work).

## Signing auto-harden (#2)
A dedicated signing key (no SSH-auth role) is now hardened to git-only the first time its **Signing setup** page is opened — previously only keys created via New key -> Sign commits were hardened, so pre-existing signing keys showed unrestricted.

- New persisted `KeyPolicy.namespaceChoiceMade` marker records a *deliberate* user toggle, so auto-harden **never re-checks a box the user cleared** (the fight-the-user bug we sidestepped earlier now solved properly).
- `isDefault` accounts for the marker (else `savePolicy` would drop a marker-only policy and re-fight). Marker is `Optional` so old `.policy` JSON still decodes.

## allowed_signers hygiene (#3)
- Deleting a key now also prunes its own `fob:<name>` line from `~/.ssh/allowed_signers` (confirmed gap: `cleanupAfterDelete` left it behind). Hand-added entries (email-commented ed25519, etc.) are **never** touched.
- The SSH checkup flags **orphaned** fob entries whose key no longer exists (app + CLI).

## Tests
New FobKit tests: backward-compat decode of old policy JSON, `isDefault` + marker, `shouldAutoHardenSigning` matrix, `AllowedSigners.removing`/`orphanedFobNames`, orphan finding. **95 tests pass.** Verified on-machine that the checkup reports no false orphans (both live signing keys) and builds/installs clean.