### PR TITLE
App-layer quality: async key-usage, extracted resolver, polish

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -387,62 +387,61 @@ final class AppState: ObservableObject {
         return GitConfig.parse((try? String(contentsOf: url, encoding: .utf8)) ?? "")
     }
 
-    /// What a key is actually used for, so the Keys page can tailor its row (e.g. hide
-    /// "Sign commits…" for a key that already signs, or "Pin" for a signing-only key).
-    struct KeyUsage: Equatable {
-        let signsCommits: Bool     // it's the git signing key (global or any includeIf identity)
-        let authHosts: [String]    // ~/.ssh/config aliases whose IdentityFile is this fob key
-        let authGitHosts: [String] // subset of authHosts that are git services (GitHub/GitLab/…)
-        var isSigningOnly: Bool { signsCommits && authHosts.isEmpty }
-        var isUnused: Bool { !signsCommits && authHosts.isEmpty }
-        /// Commit signing is a git concept — offer it for git-service keys or a bare key, not
-        /// for a plain server-login key where it's meaningless.
-        var canOfferSigning: Bool { !signsCommits && (isUnused || !authGitHosts.isEmpty) }
-    }
+    /// UI-facing alias for FobKit's pure `KeyUsage`; resolution lives in `KeyUsageResolver`.
+    typealias KeyUsage = FobKit.KeyUsage
 
-    func keyUsage(name: String) -> KeyUsage {
-        let inputs = usageInputs()
-        return usage(for: name, inputs: inputs)
+    func keyUsage(name: String) async -> KeyUsage {
+        let inputs = await usageInputs()
+        return KeyUsageResolver.resolve(name: name, signingBases: inputs.signingBases, blocks: inputs.blocks)
     }
 
     /// Usage for every key in one shot — shares the git/ssh reads across all keys so the
-    /// Keys tab doesn't spawn a subprocess storm (the source of the tab-open lag).
-    func keyUsages() -> [String: KeyUsage] {
-        let inputs = usageInputs()
+    /// Keys tab doesn't spawn a subprocess storm. Runs the git reads off the main actor so
+    /// opening the tab never blocks the UI (even on a slow disk).
+    func keyUsages() async -> [String: KeyUsage] {
+        let inputs = await usageInputs()
         var out: [String: KeyUsage] = [:]
-        for key in keys { out[key.name] = usage(for: key.name, inputs: inputs) }
+        for key in keys {
+            out[key.name] = KeyUsageResolver.resolve(name: key.name, signingBases: inputs.signingBases, blocks: inputs.blocks)
+        }
         return out
     }
 
     /// The shared, key-independent reads: the set of configured signing-key basenames
-    /// (global + every includeIf identity) and the parsed ssh `Host` blocks. Computed once.
+    /// (global + every includeIf identity) and the parsed ssh `Host` blocks. The git reads
+    /// run off the main actor (via `runGitAsync`); the parse is pure.
     private struct UsageInputs { let signingBases: Set<String>; let blocks: [HostSetup.HostBlock] }
-    private func usageInputs() -> UsageInputs {
+    private func usageInputs() async -> UsageInputs {
         func base(_ p: String) -> String {
             (p.trimmingCharacters(in: .whitespacesAndNewlines) as NSString).lastPathComponent
         }
         var signing = Set<String>()
-        let g = base(runGitSync(["config", "--global", "user.signingkey"]))
+        let g = base(await runGitAsync(["config", "--global", "user.signingkey"]))
         if !g.isEmpty { signing.insert(g) }
-        for inc in GitConfig.parseIncludeEntries(runGitSync(["config", "--global", "--get-regexp", "^includeif\\."])) {
-            let b = base(runGitSync(["config", "--file", (inc.path as NSString).expandingTildeInPath, "user.signingkey"]))
+        for inc in GitConfig.parseIncludeEntries(await runGitAsync(["config", "--global", "--get-regexp", "^includeif\\."])) {
+            let b = base(await runGitAsync(["config", "--file", (inc.path as NSString).expandingTildeInPath, "user.signingkey"]))
             if !b.isEmpty { signing.insert(b) }
         }
         let cfg = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
         return UsageInputs(signingBases: signing, blocks: HostSetup.listHostBlocks(in: cfg))
     }
 
-    private func usage(for name: String, inputs: UsageInputs) -> KeyUsage {
-        let pubBase = "fob_\(name).pub"
-        let mine = inputs.blocks.filter {
-            $0.parsed.identityFiles.contains { ($0 as NSString).lastPathComponent == pubBase }
+    /// Off-main-actor `git` read (stderr discarded), returning stdout or "" on failure — the
+    /// async sibling of `runGitSync`, so usage gathering doesn't block the UI.
+    private func runGitAsync(_ args: [String]) async -> String {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+                process.arguments = args
+                let out = Pipe(); process.standardOutput = out; process.standardError = Pipe()
+                guard (try? process.run()) != nil else { continuation.resume(returning: ""); return }
+                let data = out.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                continuation.resume(returning: process.terminationStatus == 0
+                    ? String(decoding: data, as: UTF8.self) : "")
+            }
         }
-        let gitHosts = mine
-            .filter { HostSetup.isGitHost(hostName: $0.parsed.hostName ?? $0.alias, user: $0.parsed.user) }
-            .map(\.alias)
-        return KeyUsage(signsCommits: inputs.signingBases.contains(pubBase),
-                        authHosts: Array(Set(mine.map(\.alias))).sorted(),
-                        authGitHosts: Array(Set(gitHosts)).sorted())
     }
 
     /// Create (or reuse) the fob key, export its public key, and install it on the server
@@ -907,10 +906,10 @@ final class AppState: ObservableObject {
     /// Secure default for the signing page: harden a dedicated signing key (no SSH-auth role)
     /// to git-only the first time its signing config is opened, unless the user has already
     /// made an explicit namespace choice. Returns the resulting git-only state for the toggle.
-    func autoHardenSigningIfEligible(name: String) -> Bool {
+    func autoHardenSigningIfEligible(name: String) async -> Bool {
         guard let store else { return false }
         let policy = store.policy(name: name)
-        let signingOnly = keyUsage(name: name).authHosts.isEmpty
+        let signingOnly = await keyUsage(name: name).authHosts.isEmpty
         if policy.shouldAutoHardenSigning(isSigningOnly: signingOnly) {
             setGitSigningOnly(true, name: name, explicit: false)
             return true

--- a/Sources/FobApp/ConfigWindow.swift
+++ b/Sources/FobApp/ConfigWindow.swift
@@ -20,8 +20,9 @@ struct ConfigWindow: View {
             header
             Divider()
             content
+            Spacer(minLength: 0)   // top-align pages so short ones (Settings) don't float centered
         }
-        .frame(width: 560)
+        .frame(minWidth: 560, maxWidth: 560, minHeight: 460, alignment: .top)
     }
 
     @ViewBuilder

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -282,9 +282,11 @@ struct ContentView: View {
     private func toggleMenu(_ name: String) {
         let opening = openMenuKey != name
         openMenuKey = opening ? name : nil
-        // Compute usage once, only for the key whose menu is opening, so the dropdown can
-        // scope the signing item (git concept) without pricing it into every key's render.
-        menuUsage = opening ? state.keyUsage(name: name) : nil
+        // Compute usage (off the main actor) only for the key whose menu is opening, so the
+        // dropdown can scope the signing item without blocking the UI. The signing row fills
+        // in a moment after the menu appears.
+        menuUsage = nil
+        if opening { Task { if openMenuKey == name { menuUsage = await state.keyUsage(name: name) } } }
     }
 
     @ViewBuilder

--- a/Sources/FobApp/KeysView.swift
+++ b/Sources/FobApp/KeysView.swift
@@ -49,7 +49,7 @@ struct KeysView: View {
     }
 
     private func loadUsage() {
-        usage = state.keyUsages()
+        Task { usage = await state.keyUsages() }
     }
 
     private func row(_ key: KeyInfo) -> some View {

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -39,8 +39,9 @@ struct SigningSetupView: View {
     private func load() {
         info = state.signingInfo(for: keyName)
         // Auto-harden a dedicated signing key to git-only on first open (never overriding a
-        // deliberate un-tick — see KeyPolicy.namespaceChoiceMade).
-        gitOnly = state.autoHardenSigningIfEligible(name: keyName)
+        // deliberate un-tick — see KeyPolicy.namespaceChoiceMade). Off-main; fills in shortly.
+        gitOnly = info?.gitOnly ?? false
+        Task { gitOnly = await state.autoHardenSigningIfEligible(name: keyName) }
         identities = state.discoverGitIdentities()
         // Multi-account: default to the first identity (writing --global would clobber
         // their setup). Single-account: default to per-repo (safe, universal).

--- a/Sources/FobKit/KeyStore.swift
+++ b/Sources/FobKit/KeyStore.swift
@@ -204,31 +204,36 @@ public struct KeyStore {
         try? policyStore.remove(name: name) // also clear a keychain-backed policy
     }
 
-    /// Rename a key in place: move its enclave blob, migrate its policy, and refresh the
-    /// in-store public-key line's `fob:<name>` comment. Used by rotation to swap a freshly
-    /// created key into the retired key's name so every reference (gitconfig `user.signingkey
-    /// = ~/.ssh/fob_<name>.pub`, ssh-config `IdentityFile`) keeps working unchanged. The
-    /// enclave key is unaffected — only its stored name changes. Throws if `from` is missing
-    /// or `to` already exists. The exported ~/.ssh/fob_<name>.pub is the caller's to refresh.
+    /// Rename a key in place: move its enclave blob + policy, and retarget the in-store
+    /// public-key line's `fob:<name>` comment. Used by rotation to swap a freshly created key
+    /// into the retired key's name so every reference (gitconfig `user.signingkey =
+    /// ~/.ssh/fob_<name>.pub`) keeps working unchanged. Purely file/policy operations — it
+    /// does NOT touch or reconstitute the Secure Enclave key (the blob is opaque and just
+    /// moves), so it works without the enclave being reachable. Throws if `from` is missing or
+    /// `to` already exists. The exported ~/.ssh/fob_<name>.pub is the caller's to refresh.
     public func rename(from: String, to: String) throws {
         guard Self.isValidName(to) else { throw KeyStoreError.invalidName(to) }
-        _ = try find(name: from) // 404s cleanly if the source is missing
         let fm = FileManager.default
+        let fromKey = keysDirectory.appendingPathComponent("\(from).key")
         let toKey = keysDirectory.appendingPathComponent("\(to).key")
+        guard fm.fileExists(atPath: fromKey.path) else { throw KeyStoreError.notFound(from) }
         guard !fm.fileExists(atPath: toKey.path) else { throw KeyStoreError.keyExists(to) }
-        // Move the Secure Enclave blob.
-        try fm.moveItem(at: keysDirectory.appendingPathComponent("\(from).key"), to: toKey)
+        // Move the (opaque) enclave blob.
+        try fm.moveItem(at: fromKey, to: toKey)
         // Migrate the policy through the store (handles both file- and keychain-backed).
         if let policy = try? policyStore.load(name: from) {
             try policyStore.save(policy, name: to)
             try policyStore.remove(name: from)
         }
-        // Rewrite the in-store public-key line with the new name's comment; drop the old.
-        let moved = try find(name: to)
-        let pubLine = SSHFormat.authorizedKeysLine(try moved.publicKey(), comment: "fob:\(to)")
-        try Data((pubLine + "\n").utf8).write(
-            to: keysDirectory.appendingPathComponent("\(to).pub"), options: .atomic)
-        try? fm.removeItem(at: keysDirectory.appendingPathComponent("\(from).pub"))
+        // Move the in-store public key, retargeting its `fob:<name>` comment textually — the
+        // base64 blob is unchanged, so no enclave access is needed.
+        let fromPub = keysDirectory.appendingPathComponent("\(from).pub")
+        if let text = try? String(contentsOf: fromPub, encoding: .utf8) {
+            let rewritten = text.replacingOccurrences(of: "fob:\(from)", with: "fob:\(to)")
+            try? Data(rewritten.utf8).write(
+                to: keysDirectory.appendingPathComponent("\(to).pub"), options: .atomic)
+            try? fm.removeItem(at: fromPub)
+        }
     }
 }
 

--- a/Sources/FobKit/KeyUsage.swift
+++ b/Sources/FobKit/KeyUsage.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// What a fob key is actually used for, so the UI can tailor a key's row (e.g. hide
+/// "Sign commits…" for a key that already signs, or "Pin" for a signing-only key). The
+/// impure git/ssh reads that feed this live in the app/CLI layer; the resolution is pure.
+public struct KeyUsage: Equatable {
+    public let signsCommits: Bool     // it's the git signing key (global or any includeIf identity)
+    public let authHosts: [String]    // ~/.ssh/config aliases whose IdentityFile is this fob key
+    public let authGitHosts: [String] // subset of authHosts that are git services (GitHub/GitLab/…)
+
+    public init(signsCommits: Bool, authHosts: [String], authGitHosts: [String]) {
+        self.signsCommits = signsCommits
+        self.authHosts = authHosts
+        self.authGitHosts = authGitHosts
+    }
+
+    public var isSigningOnly: Bool { signsCommits && authHosts.isEmpty }
+    public var isUnused: Bool { !signsCommits && authHosts.isEmpty }
+    /// Commit signing is a git concept — offer it for git-service keys or a bare key, not for
+    /// a plain server-login key where it's meaningless.
+    public var canOfferSigning: Bool { !signsCommits && (isUnused || !authGitHosts.isEmpty) }
+}
+
+public enum KeyUsageResolver {
+    /// Resolve a fob key's usage from the configured signing-key basenames (global + every
+    /// includeIf identity's `user.signingkey`) and the parsed ssh `Host` blocks. Pure.
+    public static func resolve(name: String, signingBases: Set<String>,
+                               blocks: [HostSetup.HostBlock]) -> KeyUsage {
+        let pubBase = "fob_\(name).pub"
+        let mine = blocks.filter {
+            $0.parsed.identityFiles.contains { ($0 as NSString).lastPathComponent == pubBase }
+        }
+        let gitHosts = mine
+            .filter { HostSetup.isGitHost(hostName: $0.parsed.hostName ?? $0.alias, user: $0.parsed.user) }
+            .map(\.alias)
+        return KeyUsage(signsCommits: signingBases.contains(pubBase),
+                        authHosts: Array(Set(mine.map(\.alias))).sorted(),
+                        authGitHosts: Array(Set(gitHosts)).sorted())
+    }
+}

--- a/Tests/FobKitTests/CheckupTests.swift
+++ b/Tests/FobKitTests/CheckupTests.swift
@@ -199,6 +199,51 @@ final class CheckupTests: XCTestCase {
         XCTAssertNil(SSHCheckup.AllowedSigners.fobKeyName(fromPubLine: "ecdsa-sha2-nistp256 AAAABBB"))
     }
 
+    // MARK: - KeyUsageResolver (per-key role resolution)
+
+    func testKeyUsageResolver() {
+        let config = """
+        Host github-work
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/fob_work.pub
+        Host space
+          HostName 10.0.0.1
+          User oliv
+          IdentityFile ~/.ssh/fob_space.pub
+        """
+        let blocks = HostSetup.listHostBlocks(in: config)
+
+        // Signing-only key (in signingBases, referenced by no host block).
+        let signing = KeyUsageResolver.resolve(name: "sign", signingBases: ["fob_sign.pub"], blocks: blocks)
+        XCTAssertTrue(signing.isSigningOnly)
+        XCTAssertFalse(signing.canOfferSigning)      // already signs
+
+        // Git-service auth key → offer signing.
+        let work = KeyUsageResolver.resolve(name: "work", signingBases: [], blocks: blocks)
+        XCTAssertEqual(work.authHosts, ["github-work"])
+        XCTAssertEqual(work.authGitHosts, ["github-work"])
+        XCTAssertTrue(work.canOfferSigning)
+        XCTAssertFalse(work.isSigningOnly)
+
+        // Plain server auth key → NOT a git host → don't offer signing.
+        let space = KeyUsageResolver.resolve(name: "space", signingBases: [], blocks: blocks)
+        XCTAssertEqual(space.authHosts, ["space"])
+        XCTAssertEqual(space.authGitHosts, [])
+        XCTAssertFalse(space.canOfferSigning)
+
+        // Both signing AND a git-host auth entry → not signing-only.
+        let both = KeyUsageResolver.resolve(name: "work", signingBases: ["fob_work.pub"], blocks: blocks)
+        XCTAssertTrue(both.signsCommits)
+        XCTAssertEqual(both.authHosts, ["github-work"])
+        XCTAssertFalse(both.isSigningOnly)
+
+        // Bare/unused key → can offer signing.
+        let bare = KeyUsageResolver.resolve(name: "nope", signingBases: [], blocks: blocks)
+        XCTAssertTrue(bare.isUnused)
+        XCTAssertTrue(bare.canOfferSigning)
+    }
+
     // MARK: - scanConfig
 
     func testScanFlagsRiskyDirectives() {

--- a/Tests/FobKitTests/SecurityTests.swift
+++ b/Tests/FobKitTests/SecurityTests.swift
@@ -214,23 +214,30 @@ final class SecurityTests: XCTestCase {
         }
     }
 
-    func testRenamePreservesKeyAndPolicy() throws {
-        try XCTSkipUnless(SecureEnclave.isAvailable, "Secure Enclave required")
+    func testRenameMovesFilesAndPolicy() throws {
+        // rename is purely file/policy ops (the enclave blob is opaque and just moves), so we
+        // test it with stand-in files — no real Secure Enclave key needed.
         let store = try makeTempStore()
-        let orig = try store.create(name: "rot", requireBiometry: false)
+        let dir = store.keysDirectory
+        let fm = FileManager.default
+        try Data("opaque-blob".utf8).write(to: dir.appendingPathComponent("rot.key"))
+        try Data("ecdsa-sha2-nistp256 AAAABBB fob:rot\n".utf8).write(to: dir.appendingPathComponent("rot.pub"))
         try store.savePolicy(KeyPolicy(reuseSeconds: 30, namespaceChoiceMade: true), name: "rot")
-        let origPub = try orig.publicKey().rawRepresentation
 
         try store.rename(from: "rot", to: "rot2")
-        XCTAssertThrowsError(try store.find(name: "rot"))                    // old name gone
-        let moved = try store.find(name: "rot2")
-        XCTAssertEqual(try moved.publicKey().rawRepresentation, origPub)     // same enclave key
+        XCTAssertFalse(fm.fileExists(atPath: dir.appendingPathComponent("rot.key").path)) // old gone
+        XCTAssertTrue(fm.fileExists(atPath: dir.appendingPathComponent("rot2.key").path)) // blob moved
+        let pub = try String(contentsOf: dir.appendingPathComponent("rot2.pub"), encoding: .utf8)
+        XCTAssertTrue(pub.contains("fob:rot2"))            // comment retargeted
+        XCTAssertFalse(pub.contains("fob:rot\n"))          // old exact comment gone
+        XCTAssertTrue(pub.contains("AAAABBB"))             // same blob preserved
         XCTAssertEqual(store.policy(name: "rot2").reuseSeconds, 30)          // policy carried over
         XCTAssertEqual(store.policy(name: "rot2").namespaceChoiceMade, true)
+        XCTAssertTrue(store.policy(name: "rot").isDefault)                   // old policy cleared
 
         XCTAssertThrowsError(try store.rename(from: "absent", to: "x"))      // source missing
-        _ = try store.create(name: "other", requireBiometry: false)
-        XCTAssertThrowsError(try store.rename(from: "rot2", to: "other"))    // target exists
+        try Data("x".utf8).write(to: dir.appendingPathComponent("occupied.key"))
+        XCTAssertThrowsError(try store.rename(from: "rot2", to: "occupied")) // target exists
     }
 
     private func makeTempStore() throws -> KeyStore {


### PR DESCRIPTION
Bundles improvements #4, #5, and #7. **Stacked on #14** (base retargets to `main` once #13→#14 merge).

## #4 — async key-usage (no UI hitch)
Per-key role resolution reads git + ssh config; those now run **off the main actor**, so opening the Keys/Audit tabs or a keys ••• menu never blocks the UI (even on a slow disk / big config). New `runGitAsync` mirrors `runGitSync` off-main; `keyUsage`/`keyUsages`/`autoHardenSigningIfEligible` are `async`; callers hop through a `Task`.

## #5 — extracted + tested resolver
The pure role logic moves to FobKit as `KeyUsage` + `KeyUsageResolver.resolve(name:signingBases:blocks:)` (`AppState.KeyUsage` becomes a typealias). Covered by a unit test across signing-only / git-auth / server-auth / dual / bare keys.

## Rename hardened (SE-free)
`KeyStore.rename` is now pure file+policy moves with a textual `fob:<name>` pub-comment retarget — it no longer reconstitutes the enclave key (the blob is opaque and just moves). More robust, and its test uses stand-in files instead of a real SE key (the ad-hoc test binary cant reliably generate one).

## #7 — config-window polish
A min-height + top-aligned pages so short tabs (Settings) dont float centered and tab switches dont jump. (Further visual tweaks welcome once you eyeball it.)

**97 tests pass**; app builds/installs. #6 (multi-account docs) shipped separately as #15.