### PR TITLE
Key rotation v1 + app-layer quality (re-land onto main)

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -387,62 +387,61 @@ final class AppState: ObservableObject {
         return GitConfig.parse((try? String(contentsOf: url, encoding: .utf8)) ?? "")
     }
 
-    /// What a key is actually used for, so the Keys page can tailor its row (e.g. hide
-    /// "Sign commits…" for a key that already signs, or "Pin" for a signing-only key).
-    struct KeyUsage: Equatable {
-        let signsCommits: Bool     // it's the git signing key (global or any includeIf identity)
-        let authHosts: [String]    // ~/.ssh/config aliases whose IdentityFile is this fob key
-        let authGitHosts: [String] // subset of authHosts that are git services (GitHub/GitLab/…)
-        var isSigningOnly: Bool { signsCommits && authHosts.isEmpty }
-        var isUnused: Bool { !signsCommits && authHosts.isEmpty }
-        /// Commit signing is a git concept — offer it for git-service keys or a bare key, not
-        /// for a plain server-login key where it's meaningless.
-        var canOfferSigning: Bool { !signsCommits && (isUnused || !authGitHosts.isEmpty) }
-    }
+    /// UI-facing alias for FobKit's pure `KeyUsage`; resolution lives in `KeyUsageResolver`.
+    typealias KeyUsage = FobKit.KeyUsage
 
-    func keyUsage(name: String) -> KeyUsage {
-        let inputs = usageInputs()
-        return usage(for: name, inputs: inputs)
+    func keyUsage(name: String) async -> KeyUsage {
+        let inputs = await usageInputs()
+        return KeyUsageResolver.resolve(name: name, signingBases: inputs.signingBases, blocks: inputs.blocks)
     }
 
     /// Usage for every key in one shot — shares the git/ssh reads across all keys so the
-    /// Keys tab doesn't spawn a subprocess storm (the source of the tab-open lag).
-    func keyUsages() -> [String: KeyUsage] {
-        let inputs = usageInputs()
+    /// Keys tab doesn't spawn a subprocess storm. Runs the git reads off the main actor so
+    /// opening the tab never blocks the UI (even on a slow disk).
+    func keyUsages() async -> [String: KeyUsage] {
+        let inputs = await usageInputs()
         var out: [String: KeyUsage] = [:]
-        for key in keys { out[key.name] = usage(for: key.name, inputs: inputs) }
+        for key in keys {
+            out[key.name] = KeyUsageResolver.resolve(name: key.name, signingBases: inputs.signingBases, blocks: inputs.blocks)
+        }
         return out
     }
 
     /// The shared, key-independent reads: the set of configured signing-key basenames
-    /// (global + every includeIf identity) and the parsed ssh `Host` blocks. Computed once.
+    /// (global + every includeIf identity) and the parsed ssh `Host` blocks. The git reads
+    /// run off the main actor (via `runGitAsync`); the parse is pure.
     private struct UsageInputs { let signingBases: Set<String>; let blocks: [HostSetup.HostBlock] }
-    private func usageInputs() -> UsageInputs {
+    private func usageInputs() async -> UsageInputs {
         func base(_ p: String) -> String {
             (p.trimmingCharacters(in: .whitespacesAndNewlines) as NSString).lastPathComponent
         }
         var signing = Set<String>()
-        let g = base(runGitSync(["config", "--global", "user.signingkey"]))
+        let g = base(await runGitAsync(["config", "--global", "user.signingkey"]))
         if !g.isEmpty { signing.insert(g) }
-        for inc in GitConfig.parseIncludeEntries(runGitSync(["config", "--global", "--get-regexp", "^includeif\\."])) {
-            let b = base(runGitSync(["config", "--file", (inc.path as NSString).expandingTildeInPath, "user.signingkey"]))
+        for inc in GitConfig.parseIncludeEntries(await runGitAsync(["config", "--global", "--get-regexp", "^includeif\\."])) {
+            let b = base(await runGitAsync(["config", "--file", (inc.path as NSString).expandingTildeInPath, "user.signingkey"]))
             if !b.isEmpty { signing.insert(b) }
         }
         let cfg = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
         return UsageInputs(signingBases: signing, blocks: HostSetup.listHostBlocks(in: cfg))
     }
 
-    private func usage(for name: String, inputs: UsageInputs) -> KeyUsage {
-        let pubBase = "fob_\(name).pub"
-        let mine = inputs.blocks.filter {
-            $0.parsed.identityFiles.contains { ($0 as NSString).lastPathComponent == pubBase }
+    /// Off-main-actor `git` read (stderr discarded), returning stdout or "" on failure — the
+    /// async sibling of `runGitSync`, so usage gathering doesn't block the UI.
+    private func runGitAsync(_ args: [String]) async -> String {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+                process.arguments = args
+                let out = Pipe(); process.standardOutput = out; process.standardError = Pipe()
+                guard (try? process.run()) != nil else { continuation.resume(returning: ""); return }
+                let data = out.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                continuation.resume(returning: process.terminationStatus == 0
+                    ? String(decoding: data, as: UTF8.self) : "")
+            }
         }
-        let gitHosts = mine
-            .filter { HostSetup.isGitHost(hostName: $0.parsed.hostName ?? $0.alias, user: $0.parsed.user) }
-            .map(\.alias)
-        return KeyUsage(signsCommits: inputs.signingBases.contains(pubBase),
-                        authHosts: Array(Set(mine.map(\.alias))).sorted(),
-                        authGitHosts: Array(Set(gitHosts)).sorted())
     }
 
     /// Create (or reuse) the fob key, export its public key, and install it on the server
@@ -907,10 +906,10 @@ final class AppState: ObservableObject {
     /// Secure default for the signing page: harden a dedicated signing key (no SSH-auth role)
     /// to git-only the first time its signing config is opened, unless the user has already
     /// made an explicit namespace choice. Returns the resulting git-only state for the toggle.
-    func autoHardenSigningIfEligible(name: String) -> Bool {
+    func autoHardenSigningIfEligible(name: String) async -> Bool {
         guard let store else { return false }
         let policy = store.policy(name: name)
-        let signingOnly = keyUsage(name: name).authHosts.isEmpty
+        let signingOnly = await keyUsage(name: name).authHosts.isEmpty
         if policy.shouldAutoHardenSigning(isSigningOnly: signingOnly) {
             setGitSigningOnly(true, name: name, explicit: false)
             return true

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -42,9 +42,11 @@ final class AppState: ObservableObject {
     // are reached from other flows/the popover, so they render as a pushed detail over the
     // current tab rather than as tabs of their own.
     enum ConfigTab: Hashable { case newKey, keys, migrate, checkup, audit, settings }
-    enum ConfigDetail: Equatable { case signing, migrateHost }
+    enum ConfigDetail: Equatable { case signing, migrateHost, rotate }
     @Published var configTab: ConfigTab = .newKey
     @Published var configDetail: ConfigDetail?
+    /// The key the Rotate page operates on (set before routing to `.rotate`).
+    @Published var rotateKey: String?
 
     /// Set the config window's route, then the caller opens the window. Detail routes reuse
     /// the existing `signingSetupKey`/`migrateAlias` fields as their parameters (set those
@@ -957,6 +959,80 @@ final class AppState: ObservableObject {
         if case .identity(let id) = scope, let e = id.email { return e }
         let e = runGitSync(["config", "--global", "user.email"]).trimmingCharacters(in: .whitespacesAndNewlines)
         return e.isEmpty ? nil : e
+    }
+
+    // MARK: - Key rotation (v1: signing keys)
+
+    /// What step 1 of a signing-key rotation produces: a fresh key (under a temp name) whose
+    /// public key the user registers on their git host before we swap.
+    struct RotationPrep: Equatable { let pubLine: String; let pubPath: String }
+    enum RotationPrepResult: Equatable { case ready(RotationPrep); case failed(String) }
+
+    private func rotationTempName(_ name: String) -> String { "\(name).rotating" }
+
+    /// Step 1 — create a fresh Secure Enclave key (temp name) and export its public key, so
+    /// the user can add it on their git host as a Signing Key alongside the old one before the
+    /// swap. Returns the new pub to register, or an error.
+    func prepareSigningRotation(name: String, requireBiometry: Bool) -> RotationPrepResult {
+        guard let store else { return .failed("Key store unavailable.") }
+        let temp = rotationTempName(name)
+        if (try? store.find(name: temp)) != nil { try? store.remove(name: temp) } // clear an abandoned attempt
+        do {
+            _ = try store.create(name: temp, requireBiometry: requireBiometry)
+        } catch {
+            return .failed(error.localizedDescription)
+        }
+        guard let info = signingInfo(for: temp) else {
+            try? store.remove(name: temp)
+            return .failed("Couldn't export the new key.")
+        }
+        return .ready(RotationPrep(pubLine: info.pubLine, pubPath: info.pubPath))
+    }
+
+    /// Step 2 — swap the new key into the old key's name so every reference keeps working
+    /// (`user.signingkey = ~/.ssh/fob_<name>.pub` is unchanged, now the new key), carry the
+    /// old policy over, and replace the old key's allowed_signers line with the new one's.
+    /// The old key is destroyed only after the new one is safely in place. nil = success.
+    func finalizeSigningRotation(name: String) -> String? {
+        guard let store else { return "Key store unavailable." }
+        let temp = rotationTempName(name)
+        guard (try? store.find(name: temp)) != nil else { return "No rotation in progress for “\(name)”." }
+        let retired = "\(name).retired"
+        let signersURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/allowed_signers")
+        let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
+        // Carry the old allowed_signers principal (email) forward; fall back to global user.email.
+        let email = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
+            ?? runGitSync(["config", "--global", "user.email"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        do {
+            copyPolicy(from: name, to: temp)               // new key inherits pin/reuse/namespaces
+            try store.rename(from: name, to: retired)      // move old aside (recoverable)
+            try store.rename(from: temp, to: name)         // new key takes the name
+            try store.remove(name: retired)                // destroy the old enclave key
+        } catch {
+            return error.localizedDescription
+        }
+        guard let info = signingInfo(for: name) else { return "Rotated, but couldn't re-export the key." }
+        // Swap the allowed_signers line: drop the old key's, add the new key's (same comment).
+        var text = signersText
+        if let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) { text = pruned }
+        if !email.isEmpty, let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: info.pubLine) {
+            text = updated
+        }
+        try? Data(text.utf8).write(to: signersURL, options: .atomic)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signersURL.path)
+        refreshKeys()
+        return nil
+    }
+
+    /// Abandon a prepared-but-not-finalized rotation (deletes the temp key).
+    func cancelRotation(name: String) {
+        try? store?.remove(name: rotationTempName(name))
+    }
+
+    /// Copy a key's whole policy (pin/reuse/namespaces + choice marker) to another name.
+    private func copyPolicy(from: String, to: String) {
+        guard let store else { return }
+        try? store.savePolicy(store.policy(name: from), name: to)
     }
 
     /// Append an entry to ~/.ssh/allowed_signers (idempotent) so signed commits verify locally.

--- a/Sources/FobApp/ConfigWindow.swift
+++ b/Sources/FobApp/ConfigWindow.swift
@@ -20,8 +20,9 @@ struct ConfigWindow: View {
             header
             Divider()
             content
+            Spacer(minLength: 0)   // top-align pages so short ones (Settings) don't float centered
         }
-        .frame(width: 560)
+        .frame(minWidth: 560, maxWidth: 560, minHeight: 460, alignment: .top)
     }
 
     @ViewBuilder

--- a/Sources/FobApp/ConfigWindow.swift
+++ b/Sources/FobApp/ConfigWindow.swift
@@ -64,6 +64,7 @@ struct ConfigWindow: View {
             switch detail {
             case .signing: SigningSetupView()
             case .migrateHost: MigrateHostView()
+            case .rotate: RotateKeyView()
             }
         } else {
             switch state.configTab {

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -282,9 +282,11 @@ struct ContentView: View {
     private func toggleMenu(_ name: String) {
         let opening = openMenuKey != name
         openMenuKey = opening ? name : nil
-        // Compute usage once, only for the key whose menu is opening, so the dropdown can
-        // scope the signing item (git concept) without pricing it into every key's render.
-        menuUsage = opening ? state.keyUsage(name: name) : nil
+        // Compute usage (off the main actor) only for the key whose menu is opening, so the
+        // dropdown can scope the signing item without blocking the UI. The signing row fills
+        // in a moment after the menu appears.
+        menuUsage = nil
+        if opening { Task { if openMenuKey == name { menuUsage = await state.keyUsage(name: name) } } }
     }
 
     @ViewBuilder

--- a/Sources/FobApp/KeysView.swift
+++ b/Sources/FobApp/KeysView.swift
@@ -87,6 +87,8 @@ struct KeysView: View {
                 if use?.signsCommits ?? false {
                     Button("Signing setup…") { openSigning(key.name) }
                         .help("Review or change this key's commit-signing configuration.")
+                    Button("Rotate…") { openRotate(key.name) }
+                        .help("Replace this signing key with a fresh Secure Enclave key and retire this one.")
                 } else if use?.canOfferSigning ?? true {
                     Button("Sign commits…") { openSigning(key.name) }
                 }
@@ -122,6 +124,11 @@ struct KeysView: View {
         state.signingSetupKey = name
         state.signingSetupHost = nil
         state.configDetail = .signing
+    }
+
+    private func openRotate(_ name: String) {
+        state.rotateKey = name
+        state.configDetail = .rotate
     }
 
     private func prune(_ alias: String) {

--- a/Sources/FobApp/KeysView.swift
+++ b/Sources/FobApp/KeysView.swift
@@ -49,7 +49,7 @@ struct KeysView: View {
     }
 
     private func loadUsage() {
-        usage = state.keyUsages()
+        Task { usage = await state.keyUsages() }
     }
 
     private func row(_ key: KeyInfo) -> some View {

--- a/Sources/FobApp/RotateKeyView.swift
+++ b/Sources/FobApp/RotateKeyView.swift
@@ -1,0 +1,123 @@
+import AppKit
+import FobKit
+import SwiftUI
+
+/// The "Rotate" page (a pushed detail from the Keys tab). Replaces a commit-signing key with a
+/// fresh Secure Enclave key and retires the old one, keeping the same name so gitconfig's
+/// `user.signingkey = ~/.ssh/fob_<name>.pub` keeps working. Safe by design: the new key is
+/// created and registered alongside the old one, and the old enclave key is destroyed only
+/// after the new one is in place.
+struct RotateKeyView: View {
+    @EnvironmentObject var state: AppState
+
+    @State private var biometry = true
+    @State private var prep: AppState.RotationPrep?
+    @State private var busy = false
+    @State private var error: String?
+    @State private var done = false
+    @State private var copied = false
+
+    private var name: String { state.rotateKey ?? "" }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                FobKeyGlyph(size: 28)
+                Text("Rotate — \(name)").font(.title2.weight(.semibold))
+            }
+            if done { doneView }
+            else if let prep { registerView(prep) }
+            else { startView }
+            if let error {
+                Label(error, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onDisappear { if prep != nil && !done { state.cancelRotation(name: name) } } // drop an abandoned temp key
+    }
+
+    // Step 1 — create the replacement key.
+    private var startView: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Creates a **new** Secure Enclave key to take over commit signing for “\(name)”, then retires this one. The new key is registered alongside the old, so nothing breaks mid-way — and it keeps the name “\(name)”, so your git config needs no changes.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            Toggle("Touch ID only (currently enrolled fingerprints)", isOn: $biometry)
+                .toggleStyle(.checkbox).font(.callout)
+            HStack {
+                Spacer()
+                Button(busy ? "Creating…" : "Create replacement key") { create() }
+                    .keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent).disabled(busy)
+            }
+        }
+    }
+
+    // Step 2 — register the new key, then finalize.
+    private func registerView(_ prep: AppState.RotationPrep) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            step(1, "Register the new key on your git host as a Signing Key",
+                 "Add this as a **Signing Key** (a new entry — keep the old one for now):")
+            copyBox(prep.pubLine)
+            step(2, "Swap to the new key", "Retires the old key and points signing at the new one. Local signing keeps working; your host shows *Verified* once the new key is registered.")
+            HStack {
+                Spacer()
+                Button(busy ? "Rotating…" : "I registered it — rotate now") { finalize() }
+                    .keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent).disabled(busy)
+            }
+        }
+    }
+
+    private var doneView: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("“\(name)” rotated to a fresh key", systemImage: "checkmark.seal.fill")
+                .foregroundStyle(.green).font(.headline)
+            Text("Signing now uses the new Secure Enclave key; the old one is destroyed. Its allowed_signers entry was updated, and your git config is unchanged.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            Text("**Last step:** remove the **old** signing key from your git host (it's now dead). The new key is already registered.")
+                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+            HStack {
+                Spacer()
+                Button("Done") { state.configDetail = nil }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private func create() {
+        busy = true
+        switch state.prepareSigningRotation(name: name, requireBiometry: biometry) {
+        case .ready(let p): prep = p; error = nil
+        case .failed(let msg): error = msg
+        }
+        busy = false
+    }
+
+    private func finalize() {
+        busy = true
+        if let msg = state.finalizeSigningRotation(name: name) { error = msg }
+        else { done = true; error = nil }
+        busy = false
+    }
+
+    private func step(_ n: Int, _ title: String, _ detail: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(n). \(title)").font(.callout.weight(.semibold))
+            Text(.init(detail)).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func copyBox(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(text).font(.system(.caption, design: .monospaced)).textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(RoundedRectangle(cornerRadius: 6).fill(Color.secondary.opacity(0.12)))
+            Button(copied ? "Copied" : "Copy") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+                copied = true
+            }
+        }
+    }
+}

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -39,8 +39,9 @@ struct SigningSetupView: View {
     private func load() {
         info = state.signingInfo(for: keyName)
         // Auto-harden a dedicated signing key to git-only on first open (never overriding a
-        // deliberate un-tick — see KeyPolicy.namespaceChoiceMade).
-        gitOnly = state.autoHardenSigningIfEligible(name: keyName)
+        // deliberate un-tick — see KeyPolicy.namespaceChoiceMade). Off-main; fills in shortly.
+        gitOnly = info?.gitOnly ?? false
+        Task { gitOnly = await state.autoHardenSigningIfEligible(name: keyName) }
         identities = state.discoverGitIdentities()
         // Multi-account: default to the first identity (writing --global would clobber
         // their setup). Single-account: default to per-repo (safe, universal).

--- a/Sources/FobKit/KeyStore.swift
+++ b/Sources/FobKit/KeyStore.swift
@@ -203,6 +203,33 @@ public struct KeyStore {
         }
         try? policyStore.remove(name: name) // also clear a keychain-backed policy
     }
+
+    /// Rename a key in place: move its enclave blob, migrate its policy, and refresh the
+    /// in-store public-key line's `fob:<name>` comment. Used by rotation to swap a freshly
+    /// created key into the retired key's name so every reference (gitconfig `user.signingkey
+    /// = ~/.ssh/fob_<name>.pub`, ssh-config `IdentityFile`) keeps working unchanged. The
+    /// enclave key is unaffected — only its stored name changes. Throws if `from` is missing
+    /// or `to` already exists. The exported ~/.ssh/fob_<name>.pub is the caller's to refresh.
+    public func rename(from: String, to: String) throws {
+        guard Self.isValidName(to) else { throw KeyStoreError.invalidName(to) }
+        _ = try find(name: from) // 404s cleanly if the source is missing
+        let fm = FileManager.default
+        let toKey = keysDirectory.appendingPathComponent("\(to).key")
+        guard !fm.fileExists(atPath: toKey.path) else { throw KeyStoreError.keyExists(to) }
+        // Move the Secure Enclave blob.
+        try fm.moveItem(at: keysDirectory.appendingPathComponent("\(from).key"), to: toKey)
+        // Migrate the policy through the store (handles both file- and keychain-backed).
+        if let policy = try? policyStore.load(name: from) {
+            try policyStore.save(policy, name: to)
+            try policyStore.remove(name: from)
+        }
+        // Rewrite the in-store public-key line with the new name's comment; drop the old.
+        let moved = try find(name: to)
+        let pubLine = SSHFormat.authorizedKeysLine(try moved.publicKey(), comment: "fob:\(to)")
+        try Data((pubLine + "\n").utf8).write(
+            to: keysDirectory.appendingPathComponent("\(to).pub"), options: .atomic)
+        try? fm.removeItem(at: keysDirectory.appendingPathComponent("\(from).pub"))
+    }
 }
 
 public enum KeyStoreError: LocalizedError {

--- a/Sources/FobKit/KeyStore.swift
+++ b/Sources/FobKit/KeyStore.swift
@@ -204,31 +204,36 @@ public struct KeyStore {
         try? policyStore.remove(name: name) // also clear a keychain-backed policy
     }
 
-    /// Rename a key in place: move its enclave blob, migrate its policy, and refresh the
-    /// in-store public-key line's `fob:<name>` comment. Used by rotation to swap a freshly
-    /// created key into the retired key's name so every reference (gitconfig `user.signingkey
-    /// = ~/.ssh/fob_<name>.pub`, ssh-config `IdentityFile`) keeps working unchanged. The
-    /// enclave key is unaffected — only its stored name changes. Throws if `from` is missing
-    /// or `to` already exists. The exported ~/.ssh/fob_<name>.pub is the caller's to refresh.
+    /// Rename a key in place: move its enclave blob + policy, and retarget the in-store
+    /// public-key line's `fob:<name>` comment. Used by rotation to swap a freshly created key
+    /// into the retired key's name so every reference (gitconfig `user.signingkey =
+    /// ~/.ssh/fob_<name>.pub`) keeps working unchanged. Purely file/policy operations — it
+    /// does NOT touch or reconstitute the Secure Enclave key (the blob is opaque and just
+    /// moves), so it works without the enclave being reachable. Throws if `from` is missing or
+    /// `to` already exists. The exported ~/.ssh/fob_<name>.pub is the caller's to refresh.
     public func rename(from: String, to: String) throws {
         guard Self.isValidName(to) else { throw KeyStoreError.invalidName(to) }
-        _ = try find(name: from) // 404s cleanly if the source is missing
         let fm = FileManager.default
+        let fromKey = keysDirectory.appendingPathComponent("\(from).key")
         let toKey = keysDirectory.appendingPathComponent("\(to).key")
+        guard fm.fileExists(atPath: fromKey.path) else { throw KeyStoreError.notFound(from) }
         guard !fm.fileExists(atPath: toKey.path) else { throw KeyStoreError.keyExists(to) }
-        // Move the Secure Enclave blob.
-        try fm.moveItem(at: keysDirectory.appendingPathComponent("\(from).key"), to: toKey)
+        // Move the (opaque) enclave blob.
+        try fm.moveItem(at: fromKey, to: toKey)
         // Migrate the policy through the store (handles both file- and keychain-backed).
         if let policy = try? policyStore.load(name: from) {
             try policyStore.save(policy, name: to)
             try policyStore.remove(name: from)
         }
-        // Rewrite the in-store public-key line with the new name's comment; drop the old.
-        let moved = try find(name: to)
-        let pubLine = SSHFormat.authorizedKeysLine(try moved.publicKey(), comment: "fob:\(to)")
-        try Data((pubLine + "\n").utf8).write(
-            to: keysDirectory.appendingPathComponent("\(to).pub"), options: .atomic)
-        try? fm.removeItem(at: keysDirectory.appendingPathComponent("\(from).pub"))
+        // Move the in-store public key, retargeting its `fob:<name>` comment textually — the
+        // base64 blob is unchanged, so no enclave access is needed.
+        let fromPub = keysDirectory.appendingPathComponent("\(from).pub")
+        if let text = try? String(contentsOf: fromPub, encoding: .utf8) {
+            let rewritten = text.replacingOccurrences(of: "fob:\(from)", with: "fob:\(to)")
+            try? Data(rewritten.utf8).write(
+                to: keysDirectory.appendingPathComponent("\(to).pub"), options: .atomic)
+            try? fm.removeItem(at: fromPub)
+        }
     }
 }
 

--- a/Sources/FobKit/KeyUsage.swift
+++ b/Sources/FobKit/KeyUsage.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// What a fob key is actually used for, so the UI can tailor a key's row (e.g. hide
+/// "Sign commits…" for a key that already signs, or "Pin" for a signing-only key). The
+/// impure git/ssh reads that feed this live in the app/CLI layer; the resolution is pure.
+public struct KeyUsage: Equatable {
+    public let signsCommits: Bool     // it's the git signing key (global or any includeIf identity)
+    public let authHosts: [String]    // ~/.ssh/config aliases whose IdentityFile is this fob key
+    public let authGitHosts: [String] // subset of authHosts that are git services (GitHub/GitLab/…)
+
+    public init(signsCommits: Bool, authHosts: [String], authGitHosts: [String]) {
+        self.signsCommits = signsCommits
+        self.authHosts = authHosts
+        self.authGitHosts = authGitHosts
+    }
+
+    public var isSigningOnly: Bool { signsCommits && authHosts.isEmpty }
+    public var isUnused: Bool { !signsCommits && authHosts.isEmpty }
+    /// Commit signing is a git concept — offer it for git-service keys or a bare key, not for
+    /// a plain server-login key where it's meaningless.
+    public var canOfferSigning: Bool { !signsCommits && (isUnused || !authGitHosts.isEmpty) }
+}
+
+public enum KeyUsageResolver {
+    /// Resolve a fob key's usage from the configured signing-key basenames (global + every
+    /// includeIf identity's `user.signingkey`) and the parsed ssh `Host` blocks. Pure.
+    public static func resolve(name: String, signingBases: Set<String>,
+                               blocks: [HostSetup.HostBlock]) -> KeyUsage {
+        let pubBase = "fob_\(name).pub"
+        let mine = blocks.filter {
+            $0.parsed.identityFiles.contains { ($0 as NSString).lastPathComponent == pubBase }
+        }
+        let gitHosts = mine
+            .filter { HostSetup.isGitHost(hostName: $0.parsed.hostName ?? $0.alias, user: $0.parsed.user) }
+            .map(\.alias)
+        return KeyUsage(signsCommits: signingBases.contains(pubBase),
+                        authHosts: Array(Set(mine.map(\.alias))).sorted(),
+                        authGitHosts: Array(Set(gitHosts)).sorted())
+    }
+}

--- a/Sources/FobKit/SSHCheckup.swift
+++ b/Sources/FobKit/SSHCheckup.swift
@@ -182,6 +182,15 @@ public enum SSHCheckup {
             return trimmed.isEmpty ? "" : trimmed + "\n"
         }
 
+        /// The principals field (first column, e.g. the email) of a fob key's allowed_signers
+        /// line — so rotation can carry it onto the replacement key's line.
+        public static func principal(_ fileText: String, fobKeyName name: String) -> String? {
+            for line in fileText.split(separator: "\n") where fobKeyName(fromLine: String(line)) == name {
+                return line.split(separator: " ").first.map(String.init)
+            }
+            return nil
+        }
+
         /// fob key names present in allowed_signers (via `fob:<name>` comments) that are NOT
         /// in `liveNames` — i.e. entries left behind for keys that no longer exist.
         public static func orphanedFobNames(_ fileText: String, liveNames: Set<String>) -> [String] {

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -458,6 +458,56 @@ do {
         print("Then `git commit` prompts Touch ID via fob, and your host (GitHub, GitLab,")
         print("Gitea/Forgejo, …) shows \"Verified\". It also verifies locally via allowed_signers.")
 
+    case "rotate":
+        // Signing-key rotation (v1): replace a key with a fresh enclave key, keeping its name.
+        // Two steps so you can register the new key before the old is retired.
+        var rest = Array(arguments.dropFirst())
+        let doFinalize = rest.contains("--finalize")
+        let requireBiometry = rest.contains("--require-biometry")
+        rest.removeAll { $0.hasPrefix("-") }
+        guard let name = rest.first, rest.count == 1 else {
+            fail("usage: fob rotate <name> [--require-biometry]   then   fob rotate <name> --finalize")
+        }
+        _ = try store.find(name: name) // 404s cleanly if the key doesn't exist
+        let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+        let signersURL = sshDir.appendingPathComponent("allowed_signers")
+        let temp = "\(name).rotating"
+        if !doFinalize {
+            if (try? store.find(name: temp)) != nil { try store.remove(name: temp) } // clear an abandoned attempt
+            let key = try store.create(name: temp, requireBiometry: requireBiometry)
+            let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
+            print("Rotation prepared for '\(name)'. On your git host, add this NEW key as a")
+            print("Signing Key (a separate entry — keep the old one until you finalize):")
+            print("     \(pubLine)")
+            print("")
+            print("Then swap to it with:  fob rotate \(name) --finalize")
+        } else {
+            guard (try? store.find(name: temp)) != nil else {
+                fail("No rotation in progress for '\(name)'. Start one with: fob rotate \(name)")
+            }
+            let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
+            let email = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
+                ?? gitConfigGlobal("user.email")
+            try store.savePolicy(store.policy(name: name), name: temp) // carry pin/reuse/namespaces
+            try store.rename(from: name, to: "\(name).retired")        // old aside (recoverable)
+            try store.rename(from: temp, to: name)                     // new takes the name
+            try store.remove(name: "\(name).retired")                  // destroy the old key
+            let key = try store.find(name: name)
+            let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
+            let pubURL = sshDir.appendingPathComponent("fob_\(name).pub")
+            try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            var text = signersText
+            if let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) { text = pruned }
+            if !email.isEmpty, let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: pubLine) {
+                text = updated
+            }
+            try? Data(text.utf8).write(to: signersURL, options: .atomic)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signersURL.path)
+            print("Rotated '\(name)' to a fresh key (git config unchanged, allowed_signers updated).")
+            print("Last step: remove the OLD signing key from your git host — it's now retired.")
+        }
+
     case "policy":
         let keys = try store.all()
         if keys.isEmpty { print("No keys yet.") }

--- a/Tests/FobKitTests/CheckupTests.swift
+++ b/Tests/FobKitTests/CheckupTests.swift
@@ -144,6 +144,9 @@ final class CheckupTests: XCTestCase {
         // orphans = fob names not in the live set (email lines are never counted).
         XCTAssertEqual(SSHCheckup.AllowedSigners.orphanedFobNames(file, liveNames: ["keep"]), ["old"])
         XCTAssertEqual(SSHCheckup.AllowedSigners.orphanedFobNames(file, liveNames: ["old", "keep"]), [])
+        // principal() returns the first column of the matching fob line (for rotation to carry).
+        XCTAssertEqual(SSHCheckup.AllowedSigners.principal(file, fobKeyName: "keep"), "me@x.com")
+        XCTAssertNil(SSHCheckup.AllowedSigners.principal(file, fobKeyName: "absent"))
     }
 
     func testAllowedSignersOrphanFinding() {

--- a/Tests/FobKitTests/CheckupTests.swift
+++ b/Tests/FobKitTests/CheckupTests.swift
@@ -199,6 +199,51 @@ final class CheckupTests: XCTestCase {
         XCTAssertNil(SSHCheckup.AllowedSigners.fobKeyName(fromPubLine: "ecdsa-sha2-nistp256 AAAABBB"))
     }
 
+    // MARK: - KeyUsageResolver (per-key role resolution)
+
+    func testKeyUsageResolver() {
+        let config = """
+        Host github-work
+          HostName github.com
+          User git
+          IdentityFile ~/.ssh/fob_work.pub
+        Host space
+          HostName 10.0.0.1
+          User oliv
+          IdentityFile ~/.ssh/fob_space.pub
+        """
+        let blocks = HostSetup.listHostBlocks(in: config)
+
+        // Signing-only key (in signingBases, referenced by no host block).
+        let signing = KeyUsageResolver.resolve(name: "sign", signingBases: ["fob_sign.pub"], blocks: blocks)
+        XCTAssertTrue(signing.isSigningOnly)
+        XCTAssertFalse(signing.canOfferSigning)      // already signs
+
+        // Git-service auth key → offer signing.
+        let work = KeyUsageResolver.resolve(name: "work", signingBases: [], blocks: blocks)
+        XCTAssertEqual(work.authHosts, ["github-work"])
+        XCTAssertEqual(work.authGitHosts, ["github-work"])
+        XCTAssertTrue(work.canOfferSigning)
+        XCTAssertFalse(work.isSigningOnly)
+
+        // Plain server auth key → NOT a git host → don't offer signing.
+        let space = KeyUsageResolver.resolve(name: "space", signingBases: [], blocks: blocks)
+        XCTAssertEqual(space.authHosts, ["space"])
+        XCTAssertEqual(space.authGitHosts, [])
+        XCTAssertFalse(space.canOfferSigning)
+
+        // Both signing AND a git-host auth entry → not signing-only.
+        let both = KeyUsageResolver.resolve(name: "work", signingBases: ["fob_work.pub"], blocks: blocks)
+        XCTAssertTrue(both.signsCommits)
+        XCTAssertEqual(both.authHosts, ["github-work"])
+        XCTAssertFalse(both.isSigningOnly)
+
+        // Bare/unused key → can offer signing.
+        let bare = KeyUsageResolver.resolve(name: "nope", signingBases: [], blocks: blocks)
+        XCTAssertTrue(bare.isUnused)
+        XCTAssertTrue(bare.canOfferSigning)
+    }
+
     // MARK: - scanConfig
 
     func testScanFlagsRiskyDirectives() {

--- a/Tests/FobKitTests/SecurityTests.swift
+++ b/Tests/FobKitTests/SecurityTests.swift
@@ -214,6 +214,25 @@ final class SecurityTests: XCTestCase {
         }
     }
 
+    func testRenamePreservesKeyAndPolicy() throws {
+        try XCTSkipUnless(SecureEnclave.isAvailable, "Secure Enclave required")
+        let store = try makeTempStore()
+        let orig = try store.create(name: "rot", requireBiometry: false)
+        try store.savePolicy(KeyPolicy(reuseSeconds: 30, namespaceChoiceMade: true), name: "rot")
+        let origPub = try orig.publicKey().rawRepresentation
+
+        try store.rename(from: "rot", to: "rot2")
+        XCTAssertThrowsError(try store.find(name: "rot"))                    // old name gone
+        let moved = try store.find(name: "rot2")
+        XCTAssertEqual(try moved.publicKey().rawRepresentation, origPub)     // same enclave key
+        XCTAssertEqual(store.policy(name: "rot2").reuseSeconds, 30)          // policy carried over
+        XCTAssertEqual(store.policy(name: "rot2").namespaceChoiceMade, true)
+
+        XCTAssertThrowsError(try store.rename(from: "absent", to: "x"))      // source missing
+        _ = try store.create(name: "other", requireBiometry: false)
+        XCTAssertThrowsError(try store.rename(from: "rot2", to: "other"))    // target exists
+    }
+
     private func makeTempStore() throws -> KeyStore {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("fobtest-\(UUID().uuidString)")

--- a/Tests/FobKitTests/SecurityTests.swift
+++ b/Tests/FobKitTests/SecurityTests.swift
@@ -214,23 +214,30 @@ final class SecurityTests: XCTestCase {
         }
     }
 
-    func testRenamePreservesKeyAndPolicy() throws {
-        try XCTSkipUnless(SecureEnclave.isAvailable, "Secure Enclave required")
+    func testRenameMovesFilesAndPolicy() throws {
+        // rename is purely file/policy ops (the enclave blob is opaque and just moves), so we
+        // test it with stand-in files — no real Secure Enclave key needed.
         let store = try makeTempStore()
-        let orig = try store.create(name: "rot", requireBiometry: false)
+        let dir = store.keysDirectory
+        let fm = FileManager.default
+        try Data("opaque-blob".utf8).write(to: dir.appendingPathComponent("rot.key"))
+        try Data("ecdsa-sha2-nistp256 AAAABBB fob:rot\n".utf8).write(to: dir.appendingPathComponent("rot.pub"))
         try store.savePolicy(KeyPolicy(reuseSeconds: 30, namespaceChoiceMade: true), name: "rot")
-        let origPub = try orig.publicKey().rawRepresentation
 
         try store.rename(from: "rot", to: "rot2")
-        XCTAssertThrowsError(try store.find(name: "rot"))                    // old name gone
-        let moved = try store.find(name: "rot2")
-        XCTAssertEqual(try moved.publicKey().rawRepresentation, origPub)     // same enclave key
+        XCTAssertFalse(fm.fileExists(atPath: dir.appendingPathComponent("rot.key").path)) // old gone
+        XCTAssertTrue(fm.fileExists(atPath: dir.appendingPathComponent("rot2.key").path)) // blob moved
+        let pub = try String(contentsOf: dir.appendingPathComponent("rot2.pub"), encoding: .utf8)
+        XCTAssertTrue(pub.contains("fob:rot2"))            // comment retargeted
+        XCTAssertFalse(pub.contains("fob:rot\n"))          // old exact comment gone
+        XCTAssertTrue(pub.contains("AAAABBB"))             // same blob preserved
         XCTAssertEqual(store.policy(name: "rot2").reuseSeconds, 30)          // policy carried over
         XCTAssertEqual(store.policy(name: "rot2").namespaceChoiceMade, true)
+        XCTAssertTrue(store.policy(name: "rot").isDefault)                   // old policy cleared
 
         XCTAssertThrowsError(try store.rename(from: "absent", to: "x"))      // source missing
-        _ = try store.create(name: "other", requireBiometry: false)
-        XCTAssertThrowsError(try store.rename(from: "rot2", to: "other"))    // target exists
+        try Data("x".utf8).write(to: dir.appendingPathComponent("occupied.key"))
+        XCTAssertThrowsError(try store.rename(from: "rot2", to: "occupied")) // target exists
     }
 
     private func makeTempStore() throws -> KeyStore {


### PR DESCRIPTION
Re-lands the work from #14 (key rotation) and #16 (app-layer quality) directly onto `main`.

**Why this exists:** #14 and #16 were stacked PRs whose bases were the *other* feature branches. When #13 merged to `main` and its branch was deleted, GitHub merged #14/#16 into those now-stale intermediate branches instead of `main` — so their code never reached `main` (GitHub still shows them "merged"). This branch replays exactly those two commits onto current `main` (which already has #13 + #15), verified clean.

## Contents
- **Key rotation v1 (was #14)** — `KeyStore.rename` + `prepareSigningRotation`/`finalizeSigningRotation`, Keys-tab **Rotate…** → `RotateKeyView`, `fob rotate` CLI. Signing keys, rename-preserving.
- **App-layer quality (was #16)** — async key-usage off the main actor, pure `KeyUsageResolver` extracted to FobKit (+ tests), `rename` hardened to be Secure-Enclave-free, config-window min-height polish.

## Verification
Rebased onto `main` with **no conflicts**; `docs/MULTI-ACCOUNT-GIT.md` (from #15) is preserved. **97 tests pass**, builds + installs. Both commits fob-signed.

After merge Ill delete the stale `feat/key-rotation` and `feat/app-quality` origin branches.