### PR TITLE
Auth-key rotation — servers & git hosts (rotation v2)

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -960,19 +960,19 @@ final class AppState: ObservableObject {
         return e.isEmpty ? nil : e
     }
 
-    // MARK: - Key rotation (v1: signing keys)
+    // MARK: - Key rotation (signing + auth keys)
 
-    /// What step 1 of a signing-key rotation produces: a fresh key (under a temp name) whose
-    /// public key the user registers on their git host before we swap.
+    /// What step 1 of a rotation produces: a fresh key (under a temp name) whose public key the
+    /// user registers on the server/git host (alongside the old one) before we swap.
     struct RotationPrep: Equatable { let pubLine: String; let pubPath: String }
     enum RotationPrepResult: Equatable { case ready(RotationPrep); case failed(String) }
 
     private func rotationTempName(_ name: String) -> String { "\(name).rotating" }
 
-    /// Step 1 — create a fresh Secure Enclave key (temp name) and export its public key, so
-    /// the user can add it on their git host as a Signing Key alongside the old one before the
-    /// swap. Returns the new pub to register, or an error.
-    func prepareSigningRotation(name: String, requireBiometry: Bool) -> RotationPrepResult {
+    /// Step 1 — create a fresh Secure Enclave key (temp name) and export its public key so the
+    /// user can add it on the server/git host alongside the old one before the swap. Role-
+    /// agnostic (signing or auth). Returns the new pub to register/install, or an error.
+    func prepareRotation(name: String, requireBiometry: Bool) -> RotationPrepResult {
         guard let store else { return .failed("Key store unavailable.") }
         let temp = rotationTempName(name)
         if (try? store.find(name: temp)) != nil { try? store.remove(name: temp) } // clear an abandoned attempt
@@ -981,27 +981,77 @@ final class AppState: ObservableObject {
         } catch {
             return .failed(error.localizedDescription)
         }
-        guard let info = signingInfo(for: temp) else {
+        guard let info = signingInfo(for: temp) else {   // exports ~/.ssh/fob_<temp>.pub
             try? store.remove(name: temp)
             return .failed("Couldn't export the new key.")
         }
         return .ready(RotationPrep(pubLine: info.pubLine, pubPath: info.pubPath))
     }
 
-    /// Step 2 — swap the new key into the old key's name so every reference keeps working
-    /// (`user.signingkey = ~/.ssh/fob_<name>.pub` is unchanged, now the new key), carry the
-    /// old policy over, and replace the old key's allowed_signers line with the new one's.
-    /// The old key is destroyed only after the new one is safely in place. nil = success.
-    func finalizeSigningRotation(name: String) -> String? {
+    /// Install the rotation's NEW key on a server (into authorized_keys), authenticating with
+    /// the CURRENT (old) fob key via the alias — so the old key stays live and there's no
+    /// lockout. Mirrors `createAndInstall` but pipes the temp key's pub.
+    func installRotationKeyOnServer(_ c: MigrationCandidate, tempPubLine: String) async -> InstallOutcome {
+        let tempPub = fobPubURL(rotationTempName(c.alias)).path
+        let fallback = HostSetup.fallbackCopyCommand(alias: c.alias, fobPubPath: tempPub, port: c.port)
+        guard let args = HostSetup.installArguments(alias: c.alias) else {
+            return .needsManual(command: fallback, detail: "")
+        }
+        let (status, output) = await runProcess("/usr/bin/ssh", args, stdin: tempPubLine + "\n")
+        if status == 0 && output.contains("fob-installed") { return .installed }
+        if status == 0 && output.contains("fob-present") { return .alreadyPresent }
+        return .needsManual(command: fallback, detail: HostSetup.sanitizeForDisplay(output))
+    }
+
+    /// Prove the rotation's NEW key works on its own (forces `-i fob_<alias>.rotating.pub`),
+    /// so a green check means the new key specifically authenticated — the old one is still
+    /// live and nothing has been removed. Handles both servers and git hosts.
+    func verifyRotationKey(_ c: MigrationCandidate) async -> (ok: Bool, message: String) {
+        guard let store else { return (false, "Key store unavailable.") }
+        let tempPub = fobPubURL(rotationTempName(c.alias)).path
+        var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
+                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", "IdentitiesOnly=yes",
+                    "-o", "IdentityAgent=\(store.socketPath)",
+                    "-i", tempPub]
+        if c.isGitHost {
+            args += ["-T"]
+            if c.port != 22 { args += ["-p", String(c.port)] }
+            args += ["\(c.user)@\(c.host)"]
+            let (_, output) = await runProcess("/usr/bin/ssh", args)
+            if HostSetup.parseSSHGreeting(output).authenticated {
+                return (true, "New key authenticated with fob — safe to swap.")
+            }
+            let tail = HostSetup.sanitizeForDisplay(output)
+            return (false, "New key not authenticated yet — add it to \(c.provider.displayName) as an Authentication Key first."
+                + (tail.isEmpty ? "" : "\n\(tail)"))
+        }
+        if c.port != 22 { args += ["-p", String(c.port)] }
+        args += ["\(c.user)@\(c.host)", "true"]
+        let (status, output) = await runProcess("/usr/bin/ssh", args)
+        guard status == 0 else {
+            let tail = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (false, "New key didn't connect — nothing changed; the old key still works."
+                + (tail.isEmpty ? "" : "\n\(tail)"))
+        }
+        return (true, "New key works — safe to swap. The old key still works until you retire it.")
+    }
+
+    /// Final step — swap the new key into the old key's name so every reference keeps working
+    /// unchanged (`~/.ssh/config` IdentityFile / gitconfig `user.signingkey` = fob_<name>.pub,
+    /// now the new key). Carries the old policy over; the old key is destroyed only after the
+    /// new one is in place. If the key signs commits, its `allowed_signers` line is swapped too
+    /// (skipped for auth-only keys, which have none). nil = success.
+    func finalizeRotation(name: String) -> String? {
         guard let store else { return "Key store unavailable." }
         let temp = rotationTempName(name)
         guard (try? store.find(name: temp)) != nil else { return "No rotation in progress for “\(name)”." }
         let retired = "\(name).retired"
         let signersURL = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh/allowed_signers")
         let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
-        // Carry the old allowed_signers principal (email) forward; fall back to global user.email.
-        let email = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
-            ?? runGitSync(["config", "--global", "user.email"]).trimmingCharacters(in: .whitespacesAndNewlines)
+        // A fob:<name> allowed_signers line ⟺ this key signs commits; its principal (email) is
+        // carried onto the new line. nil ⟹ auth-only key, so we don't touch allowed_signers.
+        let signingEmail = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
         do {
             copyPolicy(from: name, to: temp)               // new key inherits pin/reuse/namespaces
             try store.rename(from: name, to: retired)      // move old aside (recoverable)
@@ -1010,22 +1060,27 @@ final class AppState: ObservableObject {
         } catch {
             return error.localizedDescription
         }
+        // signingInfo re-exports ~/.ssh/fob_<name>.pub (now the new key), so ssh-config
+        // IdentityFile / gitconfig user.signingkey — both fob_<name>.pub — need no change.
         guard let info = signingInfo(for: name) else { return "Rotated, but couldn't re-export the key." }
-        // Swap the allowed_signers line: drop the old key's, add the new key's (same comment).
-        var text = signersText
-        if let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) { text = pruned }
-        if !email.isEmpty, let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: info.pubLine) {
-            text = updated
+        // Signing keys: swap the allowed_signers line (drop old blob, add new, same comment).
+        if let email = signingEmail, !email.isEmpty {
+            var text = signersText
+            if let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) { text = pruned }
+            if let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: info.pubLine) { text = updated }
+            try? Data(text.utf8).write(to: signersURL, options: .atomic)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signersURL.path)
         }
-        try? Data(text.utf8).write(to: signersURL, options: .atomic)
-        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signersURL.path)
+        // Drop the temp export file (its .rotating.pub is no longer referenced).
+        try? FileManager.default.removeItem(at: fobPubURL(rotationTempName(name)))
         refreshKeys()
         return nil
     }
 
-    /// Abandon a prepared-but-not-finalized rotation (deletes the temp key).
+    /// Abandon a prepared-but-not-finalized rotation (deletes the temp key + its export).
     func cancelRotation(name: String) {
         try? store?.remove(name: rotationTempName(name))
+        try? FileManager.default.removeItem(at: fobPubURL(rotationTempName(name)))
     }
 
     /// Copy a key's whole policy (pin/reuse/namespaces + choice marker) to another name.

--- a/Sources/FobApp/KeysView.swift
+++ b/Sources/FobApp/KeysView.swift
@@ -87,10 +87,15 @@ struct KeysView: View {
                 if use?.signsCommits ?? false {
                     Button("Signing setup…") { openSigning(key.name) }
                         .help("Review or change this key's commit-signing configuration.")
-                    Button("Rotate…") { openRotate(key.name) }
-                        .help("Replace this signing key with a fresh Secure Enclave key and retire this one.")
                 } else if use?.canOfferSigning ?? true {
                     Button("Sign commits…") { openSigning(key.name) }
+                }
+
+                // Rotate any key that has a role (signing or auth) — replace it with a fresh
+                // Secure Enclave key, keeping the name.
+                if let use, use.signsCommits || !use.authHosts.isEmpty {
+                    Button("Rotate…") { openRotate(key.name) }
+                        .help("Replace this key with a fresh Secure Enclave key and retire this one.")
                 }
 
                 Spacer()

--- a/Sources/FobApp/RotateKeyView.swift
+++ b/Sources/FobApp/RotateKeyView.swift
@@ -2,22 +2,36 @@ import AppKit
 import FobKit
 import SwiftUI
 
-/// The "Rotate" page (a pushed detail from the Keys tab). Replaces a commit-signing key with a
-/// fresh Secure Enclave key and retires the old one, keeping the same name so gitconfig's
-/// `user.signingkey = ~/.ssh/fob_<name>.pub` keeps working. Safe by design: the new key is
-/// created and registered alongside the old one, and the old enclave key is destroyed only
-/// after the new one is in place.
+/// The "Rotate" page (a pushed detail from the Keys tab). Replaces a key with a fresh Secure
+/// Enclave key and retires the old one, keeping the same name so every reference keeps working
+/// (ssh-config `IdentityFile` / gitconfig `user.signingkey` = fob_<name>.pub, now the new key).
+/// Role-aware: a signing key just re-registers; an auth key (server or git host) installs the
+/// new key alongside the old, verifies it, then swaps. Safe by design — the old enclave key is
+/// destroyed only after the new one is proven and in place.
 struct RotateKeyView: View {
     @EnvironmentObject var state: AppState
 
+    private enum Role { case signing, server, git }
+
+    @State private var candidate: AppState.MigrationCandidate?
     @State private var biometry = true
     @State private var prep: AppState.RotationPrep?
+    @State private var install: InstallUI?
+    @State private var addedOnWeb = false
+    @State private var verified: Bool?
+    @State private var verifyNote: String?
     @State private var busy = false
     @State private var error: String?
     @State private var done = false
     @State private var copied = false
 
+    private enum InstallUI { case done(String); case manual(command: String, detail: String) }
+
     private var name: String { state.rotateKey ?? "" }
+    private var role: Role {
+        guard let c = candidate else { return .signing }
+        return c.isGitHost ? .git : .server
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -26,8 +40,14 @@ struct RotateKeyView: View {
                 Text("Rotate — \(name)").font(.title2.weight(.semibold))
             }
             if done { doneView }
-            else if let prep { registerView(prep) }
-            else { startView }
+            else if prep == nil { startView }
+            else {
+                switch role {
+                case .signing: signingFlow
+                case .server: serverFlow
+                case .git: gitFlow
+                }
+            }
             if let error {
                 Label(error, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
@@ -35,13 +55,15 @@ struct RotateKeyView: View {
         }
         .padding(22)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear { candidate = state.migrationCandidate(alias: name) }
         .onDisappear { if prep != nil && !done { state.cancelRotation(name: name) } } // drop an abandoned temp key
     }
 
-    // Step 1 — create the replacement key.
+    // MARK: Step 1 — create the replacement key
+
     private var startView: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Creates a **new** Secure Enclave key to take over commit signing for “\(name)”, then retires this one. The new key is registered alongside the old, so nothing breaks mid-way — and it keeps the name “\(name)”, so your git config needs no changes.")
+            Text(.init(startBlurb))
                 .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
             Toggle("Touch ID only (currently enrolled fingerprints)", isOn: $biometry)
                 .toggleStyle(.checkbox).font(.callout)
@@ -53,28 +75,110 @@ struct RotateKeyView: View {
         }
     }
 
-    // Step 2 — register the new key, then finalize.
-    private func registerView(_ prep: AppState.RotationPrep) -> some View {
+    private var startBlurb: String {
+        let base = "Creates a **new** Secure Enclave key to take over for “\(name)”, then retires this one. It's added alongside the old key (no lockout) and keeps the name “\(name)”, so your config needs no changes."
+        switch role {
+        case .signing: return base + " You'll register the new key on your git host as a Signing Key."
+        case .server:  return base + " fob installs the new key on the server using your current key."
+        case .git:     return base + " You'll add the new key to your git host as an Authentication Key."
+        }
+    }
+
+    // MARK: Signing flow (register → swap)
+
+    private var signingFlow: some View {
         VStack(alignment: .leading, spacing: 14) {
-            step(1, "Register the new key on your git host as a Signing Key",
-                 "Add this as a **Signing Key** (a new entry — keep the old one for now):")
-            copyBox(prep.pubLine)
-            step(2, "Swap to the new key", "Retires the old key and points signing at the new one. Local signing keeps working; your host shows *Verified* once the new key is registered.")
-            HStack {
-                Spacer()
-                Button(busy ? "Rotating…" : "I registered it — rotate now") { finalize() }
-                    .keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent).disabled(busy)
+            step(1, "Register the new key as a Signing Key",
+                 "Add this on your git host as a **Signing Key** (a new entry — keep the old one for now):")
+            copyBox(prep!.pubLine)
+            step(2, "Swap to the new key", "Retires the old key; signing points at the new one. Verifies locally once it's in allowed_signers; your host shows *Verified* once you've registered it.")
+            finalizeButton
+        }
+    }
+
+    // MARK: Server flow (install via old key → verify → swap)
+
+    private var serverFlow: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            step(1, "Install the new key on the server") {
+                switch install {
+                case nil:
+                    Button(busy ? "Installing…" : "Install (using your current key)") { runInstall() }
+                        .disabled(busy).buttonStyle(.borderedProminent)
+                case .done(let msg):
+                    Label(msg, systemImage: "checkmark.circle.fill").font(.callout).foregroundStyle(.green)
+                case .manual(let cmd, let detail):
+                    Text(.init(HostSetup.installFailureHint(detail)))
+                        .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                    copyBox(cmd)
+                    HStack {
+                        Button("I ran it — continue") { install = .done("Installed manually.") }
+                        Button(busy ? "Retrying…" : "Retry") { runInstall() }.disabled(busy)
+                    }
+                }
+            }
+            if installedOK {
+                verifyStep
+                if verified == true { swapStep }
             }
         }
     }
+
+    // MARK: Git-host flow (register on web → verify → swap)
+
+    private var gitFlow: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            step(1, "Add the new key to \(candidate?.provider.displayName ?? "your git host")") {
+                Text("Add this as an **Authentication Key** (a new entry — keep the old one for now):")
+                    .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                copyBox(prep!.pubLine)
+                HStack {
+                    if let url = candidate?.settingsURL {
+                        Button("Open \(candidate?.provider.displayName ?? "provider") SSH keys") { state.openSettings(url) }
+                    }
+                    Button(addedOnWeb ? "Added ✓" : "I added it") { addedOnWeb = true }.disabled(addedOnWeb)
+                }
+            }
+            if addedOnWeb {
+                verifyStep
+                if verified == true { swapStep }
+            }
+        }
+    }
+
+    private var verifyStep: some View {
+        step(2, "Verify the new key (Touch ID)") {
+            Button(busy ? "Connecting…" : (verified == true ? "Re-verify" : "Verify new key")) { runVerify() }
+                .disabled(busy).buttonStyle(.borderedProminent)
+            if let verifyNote {
+                Label(verifyNote, systemImage: verified == true ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                    .font(.caption).foregroundStyle(verified == true ? .green : .red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var swapStep: some View {
+        step(3, "Swap to the new key", "Retires the old key. Its config entry is unchanged — it just points at the new key now.") {
+            finalizeButton
+        }
+    }
+
+    private var finalizeButton: some View {
+        HStack {
+            Spacer()
+            Button(busy ? "Rotating…" : "Swap & retire old key") { finalize() }
+                .keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent).disabled(busy)
+        }
+    }
+
+    // MARK: Done
 
     private var doneView: some View {
         VStack(alignment: .leading, spacing: 14) {
             Label("“\(name)” rotated to a fresh key", systemImage: "checkmark.seal.fill")
                 .foregroundStyle(.green).font(.headline)
-            Text("Signing now uses the new Secure Enclave key; the old one is destroyed. Its allowed_signers entry was updated, and your git config is unchanged.")
-                .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
-            Text("**Last step:** remove the **old** signing key from your git host (it's now dead). The new key is already registered.")
+            Text(.init(doneBlurb))
                 .font(.callout).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
             HStack {
                 Spacer()
@@ -83,26 +187,79 @@ struct RotateKeyView: View {
         }
     }
 
+    private var doneBlurb: String {
+        let base = "The new Secure Enclave key is in place under the same name; the old one is destroyed and your config is unchanged."
+        switch role {
+        case .signing: return base + " **Last step:** remove the old signing key from your git host."
+        case .server:  return base + " **Last step:** remove the old key from the server's `~/.ssh/authorized_keys`."
+        case .git:     return base + " **Last step:** remove the old key from your git host's SSH keys."
+        }
+    }
+
+    // MARK: Actions
+
+    private var installedOK: Bool { if case .done = install { return true }; return false }
+
     private func create() {
         busy = true
-        switch state.prepareSigningRotation(name: name, requireBiometry: biometry) {
+        switch state.prepareRotation(name: name, requireBiometry: biometry) {
         case .ready(let p): prep = p; error = nil
         case .failed(let msg): error = msg
         }
         busy = false
     }
 
+    private func runInstall() {
+        guard let c = candidate, let prep else { return }
+        busy = true
+        Task {
+            switch await state.installRotationKeyOnServer(c, tempPubLine: prep.pubLine) {
+            case .installed: install = .done("New key installed on \(c.host).")
+            case .alreadyPresent: install = .done("New key already on \(c.host).")
+            case .needsManual(let cmd, let detail): install = .manual(command: cmd, detail: detail)
+            case .failed(let msg): error = msg
+            }
+            busy = false
+        }
+    }
+
+    private func runVerify() {
+        guard let c = candidate else { return }
+        busy = true
+        Task {
+            let r = await state.verifyRotationKey(c)
+            verified = r.ok; verifyNote = r.message
+            busy = false
+        }
+    }
+
     private func finalize() {
         busy = true
-        if let msg = state.finalizeSigningRotation(name: name) { error = msg }
+        if let msg = state.finalizeRotation(name: name) { error = msg }
         else { done = true; error = nil }
         busy = false
     }
+
+    // MARK: Building blocks
 
     private func step(_ n: Int, _ title: String, _ detail: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             Text("\(n). \(title)").font(.callout.weight(.semibold))
             Text(.init(detail)).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private func step<Content: View>(_ n: Int, _ title: String, _ detail: String? = nil,
+                                     @ViewBuilder _ content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(n). \(title)").font(.callout.weight(.semibold))
+                if let detail {
+                    Text(.init(detail)).font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            content()
         }
     }
 

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -459,8 +459,8 @@ do {
         print("Gitea/Forgejo, …) shows \"Verified\". It also verifies locally via allowed_signers.")
 
     case "rotate":
-        // Signing-key rotation (v1): replace a key with a fresh enclave key, keeping its name.
-        // Two steps so you can register the new key before the old is retired.
+        // Rotate a key: replace it with a fresh enclave key, keeping its name so refs don't
+        // change. Two steps so you register/install the new key before the old is retired.
         var rest = Array(arguments.dropFirst())
         let doFinalize = rest.contains("--finalize")
         let requireBiometry = rest.contains("--require-biometry")
@@ -472,13 +472,29 @@ do {
         let sshDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
         let signersURL = sshDir.appendingPathComponent("allowed_signers")
         let temp = "\(name).rotating"
+        // Resolve the key's role so we print the right "add the new key" guidance.
+        let cfg = (try? String(contentsOf: sshDir.appendingPathComponent("config"), encoding: .utf8)) ?? ""
+        let hostBlock = HostSetup.listHostBlocks(in: cfg).first {
+            $0.parsed.identityFiles.contains { ($0 as NSString).lastPathComponent == "fob_\(name).pub" }
+        }
         if !doFinalize {
             if (try? store.find(name: temp)) != nil { try store.remove(name: temp) } // clear an abandoned attempt
             let key = try store.create(name: temp, requireBiometry: requireBiometry)
             let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
-            print("Rotation prepared for '\(name)'. On your git host, add this NEW key as a")
-            print("Signing Key (a separate entry — keep the old one until you finalize):")
+            print("Rotation prepared for '\(name)'. Add this NEW key alongside the old one:")
             print("     \(pubLine)")
+            print("")
+            let tempPub = sshDir.appendingPathComponent("fob_\(temp).pub").path
+            try Data((pubLine + "\n").utf8).write(to: sshDir.appendingPathComponent("fob_\(temp).pub"), options: .atomic)
+            if let b = hostBlock, HostSetup.isGitHost(hostName: b.parsed.hostName ?? name, user: b.parsed.user) {
+                print("  • Git host: add it as an Authentication Key on the provider's SSH-keys page.")
+            } else if let b = hostBlock {
+                let port = b.parsed.port ?? 22
+                print("  • Server: install it with your CURRENT key —")
+                print("      \(HostSetup.fallbackCopyCommand(alias: name, fobPubPath: tempPub, port: port))")
+            } else {
+                print("  • Signing: add it on your git host as a Signing Key.")
+            }
             print("")
             print("Then swap to it with:  fob rotate \(name) --finalize")
         } else {
@@ -486,8 +502,9 @@ do {
                 fail("No rotation in progress for '\(name)'. Start one with: fob rotate \(name)")
             }
             let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
-            let email = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
-                ?? gitConfigGlobal("user.email")
+            // A fob:<name> allowed_signers line ⟺ signing key; carry its principal. nil ⟹ auth-
+            // only, so don't touch allowed_signers (avoids adding a spurious line).
+            let signingEmail = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
             try store.savePolicy(store.policy(name: name), name: temp) // carry pin/reuse/namespaces
             try store.rename(from: name, to: "\(name).retired")        // old aside (recoverable)
             try store.rename(from: temp, to: name)                     // new takes the name
@@ -497,15 +514,16 @@ do {
             let pubURL = sshDir.appendingPathComponent("fob_\(name).pub")
             try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
             try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
-            var text = signersText
-            if let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) { text = pruned }
-            if !email.isEmpty, let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: pubLine) {
-                text = updated
+            try? FileManager.default.removeItem(at: sshDir.appendingPathComponent("fob_\(temp).pub"))
+            if let email = signingEmail, !email.isEmpty {
+                var text = signersText
+                if let pruned = SSHCheckup.AllowedSigners.removing(text, fobKeyName: name) { text = pruned }
+                if let updated = SSHCheckup.AllowedSigners.appending(text, email: email, pubLine: pubLine) { text = updated }
+                try? Data(text.utf8).write(to: signersURL, options: .atomic)
+                try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signersURL.path)
             }
-            try? Data(text.utf8).write(to: signersURL, options: .atomic)
-            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: signersURL.path)
-            print("Rotated '\(name)' to a fresh key (git config unchanged, allowed_signers updated).")
-            print("Last step: remove the OLD signing key from your git host — it's now retired.")
+            print("Rotated '\(name)' to a fresh key (config unchanged; old key destroyed).")
+            print("Last step: remove the OLD key from the server/git host — it's now retired.")
         }
 
     case "policy":


### PR DESCRIPTION
Extends key rotation from signing keys (v0.13.0) to **auth** keys — servers and git hosts — reusing `rename` + `copyPolicy` and the migrate sub-actions. Rename-preserving: `~/.ssh/config`'s `IdentityFile fob_<alias>.pub` keeps working (now the new key) with **no config edit**.

## Flow (auth key)
1. Create temp key, export its pub.
2. Add the new key **alongside** the old — server: fob installs it via your CURRENT key (no lockout); git host: you add it on the web.
3. **Verify** the new key on its own (`-i fob_<alias>.rotating.pub`, Touch ID).
4. **Swap** (rename-preserving) — old key destroyed only after the new one is verified and in place.
5. Reminder to remove the old key from the server/host.

## Changes
- `AppState`: `prepareSigningRotation` → `prepareRotation` (role-agnostic); `finalizeSigningRotation` → **`finalizeRotation`** (unified — swaps the key, and swaps the `allowed_signers` line **only when the key signs**, so an auth-only key never gets a spurious entry). New `installRotationKeyOnServer` + `verifyRotationKey`.
- `RotateKeyView` is now **role-aware** (signing / server / git host).
- Keys tab: **Rotate…** shows for any key with a role (signing *or* auth).
- CLI `fob rotate`: role-aware guidance; `--finalize` gates the allowed_signers swap on signing.

## Verification
97 tests pass (rename / copyPolicy / AllowedSigners / KeyUsageResolver cover the pure logic). Install/verify are app-driven (the unsigned CLI can't complete ssh pubkey auth to a host — same as Migrate), so drive on **throwaway** server + git-host keys in the app: Rotate… → install/register new → verify → swap → old key file gone, config unchanged, connection works with the new key; then remove the old key on the host.

Completes key rotation across all key roles.