### PR TITLE
In-app update nudge (opt-out)

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -23,6 +23,17 @@ final class AppState: ObservableObject {
     @Published private(set) var keys: [KeyInfo] = []
     @Published private(set) var feed: [AgentEvent] = []
     @Published private(set) var launchAtLogin = false
+    /// A newer release than the running build, if the update check found one.
+    struct AvailableUpdate: Equatable { let version: String; let url: URL }
+    @Published private(set) var updateAvailable: AvailableUpdate?
+    /// Whether fob checks GitHub for new releases (once/day, opt-out). Persisted.
+    @Published var checkForUpdates: Bool = (UserDefaults.standard.object(forKey: "fob.checkForUpdates") as? Bool) ?? true {
+        didSet {
+            UserDefaults.standard.set(checkForUpdates, forKey: "fob.checkForUpdates")
+            if checkForUpdates { Task { await checkForUpdatesNow(force: true) } }
+            else { updateAvailable = nil }
+        }
+    }
     /// Non-nil when the agent could not start (e.g. another agent holds the lock).
     @Published private(set) var fatalError: String?
     /// Transient error from the most recent key action, shown then cleared.
@@ -72,6 +83,42 @@ final class AppState: ObservableObject {
         refreshKeys()
         refreshLoginItem()
         startAgent()
+        Task { await checkForUpdatesNow() }
+    }
+
+    // MARK: - Update check (opt-out; queries GitHub's public releases API only)
+
+    /// The running app's version (CFBundleShortVersionString), or nil outside a bundle.
+    var appVersion: String? { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String }
+
+    private static let releasesAPI = URL(string: "https://api.github.com/repos/olivierzol/fob/releases/latest")!
+    private static let releasesPage = URL(string: "https://github.com/olivierzol/fob/releases/latest")!
+    private let lastUpdateCheckKey = "fob.lastUpdateCheck"
+
+    /// Check GitHub for a newer release and set `updateAvailable`. Throttled to ~once/day
+    /// unless `force`. Silent on any failure (it's a background nicety) and a no-op when the
+    /// preference is off or the running version is unknown. Sends no data — a plain GET of the
+    /// public "latest release" endpoint.
+    func checkForUpdatesNow(force: Bool = false) async {
+        guard checkForUpdates, let current = appVersion else { return }
+        let defaults = UserDefaults.standard
+        if !force, let last = defaults.object(forKey: lastUpdateCheckKey) as? Date,
+           Date().timeIntervalSince(last) < 24 * 3600 { return }
+        var req = URLRequest(url: Self.releasesAPI)
+        req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.timeoutInterval = 10
+        guard let (data, resp) = try? await URLSession.shared.data(for: req),
+              (resp as? HTTPURLResponse)?.statusCode == 200,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tag = json["tag_name"] as? String else { return }
+        defaults.set(Date(), forKey: lastUpdateCheckKey)
+        if UpdateCheck.isNewer(tag, than: current) {
+            let url = (json["html_url"] as? String).flatMap(URL.init) ?? Self.releasesPage
+            updateAvailable = AvailableUpdate(
+                version: tag.trimmingCharacters(in: CharacterSet(charactersIn: "vV ")), url: url)
+        } else {
+            updateAvailable = nil
+        }
     }
 
     // MARK: - Agent lifecycle

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -58,6 +58,7 @@ struct ContentView: View {
 
     @State private var openMenuKey: String?
     @State private var menuUsage: AppState.KeyUsage?
+    @State private var updateCopied = false
 
     private var t: Theme { Theme.current(scheme) }
     private let width: CGFloat = 360
@@ -66,6 +67,7 @@ struct ContentView: View {
         VStack(alignment: .leading, spacing: 0) {
             header
             divider
+            if state.updateAvailable != nil { updateBanner; divider }
             keysSection
             divider
             newKeySection
@@ -116,6 +118,30 @@ struct ContentView: View {
                 inlineError(err, systemImage: nil)
             }
         }
+    }
+
+    private var updateBanner: some View {
+        HStack(spacing: 9) {
+            Image(systemName: "arrow.up.circle.fill").foregroundStyle(Theme.accent)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("Update available").font(.system(size: 12, weight: .semibold)).foregroundStyle(t.text)
+                if let u = state.updateAvailable {
+                    Text("\(state.appVersion.map { "v\($0) → " } ?? "")v\(u.version)")
+                        .font(.system(size: 11)).foregroundStyle(t.sub)
+                }
+            }
+            Spacer()
+            Button("Notes") { if let u = state.updateAvailable { NSWorkspace.shared.open(u.url) } }
+                .buttonStyle(.plain).font(.system(size: 11, weight: .medium)).foregroundStyle(Theme.accent)
+            Button(updateCopied ? "Copied" : "Copy `brew upgrade`") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString("brew upgrade --cask fob", forType: .string)
+                updateCopied = true
+            }
+            .buttonStyle(.plain).font(.system(size: 11, weight: .medium)).foregroundStyle(Theme.accent)
+        }
+        .padding(.horizontal, 14).padding(.vertical, 10)
+        .background(Theme.accent.opacity(0.08))
     }
 
     private func inlineError(_ message: String, systemImage: String?) -> some View {

--- a/Sources/FobApp/SettingsView.swift
+++ b/Sources/FobApp/SettingsView.swift
@@ -5,12 +5,17 @@ import SwiftUI
 /// The Settings page: app-level preferences that used to live in the popover footer.
 struct SettingsView: View {
     @EnvironmentObject var state: AppState
+    @State private var checking = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 10) {
                 FobKeyGlyph(size: 28)
                 Text("Settings").font(.title2.weight(.semibold))
+                Spacer()
+                if let v = state.appVersion {
+                    Text("v\(v)").font(.caption).foregroundStyle(.secondary)
+                }
             }
 
             Toggle(isOn: Binding(get: { state.launchAtLogin },
@@ -22,6 +27,31 @@ struct SettingsView: View {
                 }
             }
             .toggleStyle(.checkbox)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle(isOn: Binding(get: { state.checkForUpdates },
+                                     set: { state.checkForUpdates = $0 })) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Check for updates automatically").font(.callout)
+                        Text("Once a day, fob checks GitHub's public releases for a newer version. No data about you is sent.")
+                            .font(.caption).foregroundStyle(.secondary).fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .toggleStyle(.checkbox)
+                HStack(spacing: 8) {
+                    Button(checking ? "Checking…" : "Check now") {
+                        checking = true
+                        Task { await state.checkForUpdatesNow(force: true); checking = false }
+                    }
+                    .disabled(checking)
+                    if let u = state.updateAvailable {
+                        Text("v\(u.version) available").font(.caption).foregroundStyle(Theme.accent)
+                    } else if !checking {
+                        Text("Up to date.").font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.leading, 20)
+            }
 
             Divider()
 

--- a/Sources/FobKit/UpdateCheck.swift
+++ b/Sources/FobKit/UpdateCheck.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Pure version comparison for the in-app "update available" nudge. The network fetch (the
+/// GitHub releases API) lives in the app layer; this just decides whether a fetched tag is
+/// newer than the running version.
+public enum UpdateCheck {
+    /// True if `latest` is a strictly newer dotted version than `current`. Tolerates a leading
+    /// `v` and differing component counts (missing = 0). Non-numeric suffixes (e.g. a
+    /// `-beta`) are treated as their leading number, so pre-releases don't spuriously trigger.
+    public static func isNewer(_ latest: String, than current: String) -> Bool {
+        func parts(_ s: String) -> [Int] {
+            s.trimmingCharacters(in: CharacterSet(charactersIn: "vV "))
+                .split(separator: ".")
+                .map { Int($0.prefix { $0.isNumber }) ?? 0 }
+        }
+        let a = parts(latest), b = parts(current)
+        for i in 0..<max(a.count, b.count) {
+            let x = i < a.count ? a[i] : 0
+            let y = i < b.count ? b[i] : 0
+            if x != y { return x > y }
+        }
+        return false
+    }
+}

--- a/Tests/FobKitTests/UpdateCheckTests.swift
+++ b/Tests/FobKitTests/UpdateCheckTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+@testable import FobKit
+
+final class UpdateCheckTests: XCTestCase {
+    func testIsNewer() {
+        XCTAssertTrue(UpdateCheck.isNewer("v0.15.0", than: "0.14.0"))
+        XCTAssertTrue(UpdateCheck.isNewer("0.14.1", than: "0.14.0"))
+        XCTAssertTrue(UpdateCheck.isNewer("v1.0.0", than: "v0.14.0"))
+        XCTAssertTrue(UpdateCheck.isNewer("0.14.0", than: "0.13.9"))
+        XCTAssertFalse(UpdateCheck.isNewer("v0.14.0", than: "v0.14.0"))       // equal
+        XCTAssertFalse(UpdateCheck.isNewer("v0.13.1", than: "0.14.0"))        // older
+        XCTAssertFalse(UpdateCheck.isNewer("0.14", than: "0.14.0"))           // 0.14 == 0.14.0
+        XCTAssertFalse(UpdateCheck.isNewer("0.14.0", than: "0.14"))           // symmetric
+        // Pre-release suffix treated as its leading number (no spurious update).
+        XCTAssertFalse(UpdateCheck.isNewer("v0.14.0-beta", than: "v0.14.0"))
+    }
+}


### PR DESCRIPTION
A distributed menu-bar app had no way to tell users a newer version exists (only `brew upgrade` would surface it). fob now checks GitHub's public releases API ~once/day and shows a subtle banner in the panel when a newer version is out — with a **Release notes** link and a copyable **`brew upgrade --cask fob`**.

## Design
- **Zero new dependencies** — a plain GET of `/releases/latest` (no data about the user is sent) + a pure version comparison. No Sparkle, no auto-install (keeps fob's zero-dep, no-auto-mutation ethos).
- **Opt-out** — Settings → "Check for updates automatically" (default on), plus a "Check now" button and the running version. Turning it off clears any pending banner and makes no network calls.
- **Silent + safe** — no-op on any failure, when disabled, or when the running version is unknown (outside the .app bundle). Throttled to once/day (cached in UserDefaults); 10s timeout.

## Pieces
- `FobKit.UpdateCheck.isNewer` (pure, `v`-prefix + differing-component tolerant, pre-release-safe) + unit test.
- `AppState`: `checkForUpdates` pref (persisted), `updateAvailable`, `checkForUpdatesNow(force:)`, run on launch.
- Popover banner (ContentView) + Settings toggle/Check-now/version.

## Verification
98 tests pass; GitHub API response shape confirmed (`tag_name`, `html_url`). The banner only renders when the running version is behind the latest release, so it won't show on a current build — it'll appear naturally at the next release. (I can also demo it live with a throwaway lower-versioned local build.)