### PR TITLE
Checkup: flag known_hosts you've never set up with fob

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -59,6 +59,11 @@ final class AppState: ObservableObject {
     /// The key the Rotate page operates on (set before routing to `.rotate`).
     @Published var rotateKey: String?
 
+    /// A host to pre-fill on the New key page (set from a checkup finding, then routed to
+    /// `.newKey`). Consumed and cleared by `HostSetupView` on appear.
+    struct NewKeyPrefill: Equatable { let host: String; let isGit: Bool }
+    @Published var newKeyPrefill: NewKeyPrefill?
+
     /// Set the config window's route, then the caller opens the window. Detail routes reuse
     /// the existing `signingSetupKey`/`migrateAlias` fields as their parameters (set those
     /// first). Passing a tab clears any active detail.
@@ -770,6 +775,18 @@ final class AppState: ObservableObject {
                 title: "Commit signing uses a non-fob key",
                 detail: "Your git signing key isn't a fob key. Move it so commit signatures are Touch ID-gated.",
                 fix: .signing))
+        }
+
+        // 3c. Hosts you've connected to (in known_hosts) that aren't set up with fob at all —
+        // e.g. reached once with a password, so there's no ~/.ssh/config entry to migrate.
+        let khText = (try? String(contentsOf: sshDir.appendingPathComponent("known_hosts"), encoding: .utf8)) ?? ""
+        for entry in SSHCheckup.unconfiguredKnownHosts(knownHosts: khText, sshConfig: config) {
+            let isGit = HostSetup.isGitHost(hostName: entry.host, user: nil)
+            let kind = isGit ? "git host" : "server"
+            findings.append(.init(severity: .opportunity, category: "Opportunity",
+                title: "“\(entry.host)” isn't set up with fob",
+                detail: "You've connected to this \(kind) (it's in ~/.ssh/known_hosts) but it has no fob key. Add a Touch ID-gated Secure Enclave key for it.",
+                fix: .setupHost(host: entry.host, isGit: isGit)))
         }
 
         // 3b. fob signing set up, but can it be verified locally?

--- a/Sources/FobApp/CheckupView.swift
+++ b/Sources/FobApp/CheckupView.swift
@@ -101,6 +101,12 @@ struct CheckupView: View {
                 state.migrateAlias = alias
                 state.configDetail = .migrateHost
             }.font(.caption).padding(.top, 2)
+        case .setupHost(let host, let isGit):
+            Button("Set up \(host)…") {
+                state.newKeyPrefill = .init(host: host, isGit: isGit)
+                state.configDetail = nil
+                state.configTab = .newKey
+            }.font(.caption).padding(.top, 2)
         case .signing:
             Text("Fix: a key's ••• → “Use for commit signing…”.")
                 .font(.caption).foregroundStyle(.tertiary)

--- a/Sources/FobApp/HostSetupView.swift
+++ b/Sources/FobApp/HostSetupView.swift
@@ -44,6 +44,7 @@ struct HostSetupView: View {
         }
         .padding(22)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear(perform: applyPrefill)
     }
 
     // MARK: Form
@@ -190,6 +191,24 @@ struct HostSetupView: View {
                 Spacer()
                 Button("Done") { resetForm() }.keyboardShortcut(.defaultAction).buttonStyle(.borderedProminent)
             }
+        }
+    }
+
+    /// Consume a one-shot prefill routed from a checkup finding: pick the mode and fill the
+    /// host so the user lands on the right form with the box already typed in.
+    private func applyPrefill() {
+        guard let p = state.newKeyPrefill else { return }
+        state.newKeyPrefill = nil
+        let label = p.host.split(separator: ".").first.map(String.init) ?? p.host
+        if p.isGit {
+            mode = .git
+            provider = HostSetup.gitProvider(forHost: p.host)
+            if provider == .other, customHost.isEmpty { customHost = p.host }
+            if gitAlias.isEmpty { gitAlias = label }
+        } else {
+            mode = .server
+            if host.isEmpty { host = p.host }
+            if alias.isEmpty { alias = label }
         }
     }
 

--- a/Sources/FobKit/SSHCheckup.swift
+++ b/Sources/FobKit/SSHCheckup.swift
@@ -21,10 +21,11 @@ public enum SSHCheckup {
 
     /// What the UI/CLI can offer for a finding (all opt-in; the checkup never acts itself).
     public enum FixHint: Equatable {
-        case migrate(alias: String) // open the Migrate flow for this host
-        case signing               // open the commit-signing flow
-        case command(String)       // copy-paste guidance (a config line / chmod)
-        case revealFile(String)    // reveal a key file in Finder
+        case migrate(alias: String)              // open the Migrate flow for this host
+        case setupHost(host: String, isGit: Bool) // open New key, prefilled for this host
+        case signing                            // open the commit-signing flow
+        case command(String)                    // copy-paste guidance (a config line / chmod)
+        case revealFile(String)                 // reveal a key file in Finder
         case none
     }
 
@@ -124,6 +125,66 @@ public enum SSHCheckup {
         return Finding(severity: .high, category: "Key", title: "“\(name)” is unencrypted and unused",
             detail: "This private key is stored unencrypted and no ~/.ssh/config host or your git signing config references it — you've likely migrated off it to fob. Delete it, and remove it from any account/server that still trusts it.",
             fix: .command("rm \(path) \(path).pub"))
+    }
+
+    // MARK: - known_hosts (hosts you've connected to but never set up with fob)
+
+    /// One connectable host recovered from `~/.ssh/known_hosts`.
+    public struct KnownHostEntry: Equatable {
+        public let host: String   // hostname or IP (bracket/port form already stripped)
+        public let port: Int?     // non-nil only for a `[host]:port` entry
+        public init(host: String, port: Int?) { self.host = host; self.port = port }
+    }
+
+    /// Parse `~/.ssh/known_hosts` into the distinct hosts you've actually connected to.
+    /// Skips comments, `@cert-authority`/`@revoked` marker lines, and wildcard patterns.
+    /// Hashed entries (`|1|…`, from `HashKnownHosts yes`) can't be reversed to a name, so
+    /// they're not returned — only *counted*, so the caller can note them.
+    public static func parseKnownHosts(_ text: String) -> (hosts: [KnownHostEntry], hashedCount: Int) {
+        var out: [KnownHostEntry] = []
+        var seen = Set<String>()
+        var hashed = 0
+        for rawLine in text.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") || line.hasPrefix("@") { continue }
+            // The first whitespace-delimited field is a comma-separated host-pattern list.
+            guard let field = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).first else { continue }
+            if field.hasPrefix("|") { hashed += 1; continue } // |1|salt|hash — unreadable
+            for tokenSub in field.split(separator: ",") {
+                let token = String(tokenSub)
+                if token.contains("*") || token.contains("?") || token.hasPrefix("!") { continue }
+                let (host, port) = splitHostPort(token)
+                let low = host.lowercased()
+                if host.isEmpty || low == "localhost" || host == "127.0.0.1" || host == "::1" { continue }
+                let key = "\(low)|\(port.map(String.init) ?? "")"
+                if seen.insert(key).inserted { out.append(KnownHostEntry(host: host, port: port)) }
+            }
+        }
+        return (out, hashed)
+    }
+
+    /// Hosts present in `known_hosts` but absent from `~/.ssh/config` — neither as a literal
+    /// `Host` alias nor a `HostName` value — i.e. hosts you've connected to (often via a
+    /// password) but never set up with a key. These are the "offer a fob key" candidates.
+    public static func unconfiguredKnownHosts(knownHosts: String, sshConfig: String) -> [KnownHostEntry] {
+        var configured = Set<String>()
+        for b in HostSetup.listHostBlocks(in: sshConfig) {
+            configured.insert(b.alias.lowercased())
+            if let h = b.parsed.hostName?.lowercased() { configured.insert(h) }
+        }
+        return parseKnownHosts(knownHosts).hosts.filter { !configured.contains($0.host.lowercased()) }
+    }
+
+    /// `[host]:port` → (host, port); bracketless `host` → (host, nil). Bare IPv6 (no brackets)
+    /// is left whole (its colons aren't a port), matching OpenSSH's own known_hosts format.
+    static func splitHostPort(_ token: String) -> (String, Int?) {
+        if token.hasPrefix("["), let close = token.firstIndex(of: "]") {
+            let host = String(token[token.index(after: token.startIndex)..<close])
+            let rest = token[token.index(after: close)...]
+            if rest.hasPrefix(":"), let p = Int(rest.dropFirst()) { return (host, p) }
+            return (host, nil)
+        }
+        return (token, nil)
     }
 
     // MARK: - allowed_signers (local commit-signature verification)

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -185,6 +185,17 @@ func sshCheckupFindings(fobKeyBlobs: Set<String>, fobKeyNames: Set<String>) -> [
             title: "“\(block.alias)” still uses an on-disk key",
             detail: "Migrate it to a fob key:  fob adopt \(block.alias)", fix: .none))
     }
+
+    // Hosts in known_hosts you've connected to but never set up with fob (no config entry).
+    let khText = (try? String(contentsOf: sshDir.appendingPathComponent("known_hosts"), encoding: .utf8)) ?? ""
+    for entry in SSHCheckup.unconfiguredKnownHosts(knownHosts: khText, sshConfig: config) {
+        let kind = HostSetup.isGitHost(hostName: entry.host, user: nil) ? "git host" : "server"
+        findings.append(.init(severity: .opportunity, category: "Opportunity",
+            title: "“\(entry.host)” isn't set up with fob",
+            detail: "You've connected to this \(kind) but it has no fob key. Add one:  fob setup \(entry.host)",
+            fix: .none))
+    }
+
     let gitconfig = (try? String(contentsOf: home.appendingPathComponent(".gitconfig"), encoding: .utf8)) ?? ""
     let signing = GitConfig.parse(gitconfig)
     if (signing.signingKey != nil || signing.format != nil), !signing.usesFob {

--- a/Tests/FobKitTests/KnownHostsTests.swift
+++ b/Tests/FobKitTests/KnownHostsTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import FobKit
+
+final class KnownHostsTests: XCTestCase {
+    private func hosts(_ text: String) -> [String] {
+        SSHCheckup.parseKnownHosts(text).hosts.map(\.host)
+    }
+
+    func testPlaintextHostsAndDedup() {
+        let kh = """
+        github.com ssh-ed25519 AAAAC3Nza...
+        example.com ssh-rsa AAAAB3Nza...
+        github.com ecdsa-sha2-nistp256 AAAAE2Vj...
+        """
+        // github.com appears twice (two key types) → one entry.
+        XCTAssertEqual(hosts(kh), ["github.com", "example.com"])
+    }
+
+    func testCommaListAndIPs() {
+        let kh = "server.local,192.168.1.20 ssh-ed25519 AAAAC3Nza..."
+        XCTAssertEqual(hosts(kh), ["server.local", "192.168.1.20"])
+    }
+
+    func testBracketHostPort() {
+        let kh = "[bastion.example.com]:2222 ssh-ed25519 AAAAC3Nza..."
+        let parsed = SSHCheckup.parseKnownHosts(kh).hosts
+        XCTAssertEqual(parsed.first?.host, "bastion.example.com")
+        XCTAssertEqual(parsed.first?.port, 2222)
+    }
+
+    func testHashedCountedNotReturned() {
+        let kh = """
+        |1|abc123=|def456= ssh-ed25519 AAAAC3Nza...
+        plain.example.com ssh-ed25519 AAAAC3Nza...
+        """
+        let r = SSHCheckup.parseKnownHosts(kh)
+        XCTAssertEqual(r.hashedCount, 1)
+        XCTAssertEqual(r.hosts.map(\.host), ["plain.example.com"])
+    }
+
+    func testSkipsMarkersCommentsWildcardsAndLocalhost() {
+        let kh = """
+        # a comment
+        @cert-authority *.example.com ssh-ed25519 AAAAC3Nza...
+        @revoked old.example.com ssh-ed25519 AAAAC3Nza...
+        *.wild.net ssh-ed25519 AAAAC3Nza...
+        localhost ssh-ed25519 AAAAC3Nza...
+        127.0.0.1 ssh-ed25519 AAAAC3Nza...
+        keep.example.com ssh-ed25519 AAAAC3Nza...
+        """
+        XCTAssertEqual(hosts(kh), ["keep.example.com"])
+    }
+
+    func testEmpty() {
+        XCTAssertTrue(hosts("").isEmpty)
+        XCTAssertEqual(SSHCheckup.parseKnownHosts("").hashedCount, 0)
+    }
+
+    func testUnconfiguredExcludesConfiguredAliasAndHostName() {
+        let kh = """
+        newbox.example.net ssh-ed25519 AAAAC3Nza...
+        10.0.0.5 ssh-ed25519 AAAAC3Nza...
+        github.com ssh-ed25519 AAAAC3Nza...
+        """
+        // config: an alias "gh" → HostName github.com, and a host whose HostName is the IP.
+        let cfg = """
+        Host gh
+          HostName github.com
+          IdentityAgent ~/.fob/agent.sock
+        Host inbox
+          HostName 10.0.0.5
+        """
+        let flagged = SSHCheckup.unconfiguredKnownHosts(knownHosts: kh, sshConfig: cfg).map(\.host)
+        // github.com (matched by HostName) and 10.0.0.5 (matched by HostName) are excluded;
+        // only the never-configured host remains.
+        XCTAssertEqual(flagged, ["newbox.example.net"])
+    }
+
+    func testUnconfiguredEmptyWhenAllConfigured() {
+        let kh = "onlybox.example.com ssh-ed25519 AAAAC3Nza..."
+        let cfg = "Host onlybox.example.com\n  HostName onlybox.example.com\n"
+        XCTAssertTrue(SSHCheckup.unconfiguredKnownHosts(knownHosts: kh, sshConfig: cfg).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes a real gap: `ssh` to a host with a password → its key lands in `~/.ssh/known_hosts`, but no `~/.ssh/config` entry is written. The checkup discovered hosts **only from config**, so it never saw that host and had nothing to offer. Now it flags any `known_hosts` host with no config entry and offers to add a Touch ID-gated fob key.

## What it does
- **Detection** (`FobKit`, pure + tested):
  - `parseKnownHosts` — comma lists, `[host]:port`, skips comments / `@cert-authority` / `@revoked` / wildcards / `localhost`; **counts** unreadable hashed (`|1|`) entries rather than guessing.
  - `unconfiguredKnownHosts(knownHosts:sshConfig:)` — dedups against config `Host` aliases **and** `HostName`s. Shared by the app and CLI (no duplication).
- **App**: one `IMPROVE` finding per un-configured host with a **“Set up ‹host›…”** button that opens the **New key** tab prefilled for the host, choosing git-host vs server via `isGitHost`.
- **CLI**: same finding in `fob checkup` with `fob setup ‹host›` guidance.

## Notes
- Lists **all** un-configured hosts including raw IPs (deliberate); one finding each, low `IMPROVE` severity. Easy to switch to a single grouped finding later if it reads noisy.
- Only *offers* to start setup — `known_hosts` records the host but not the username or whether you still have access, so it can never auto-add.

## Verification
- `swift build` clean; **106 tests pass** (`swift test`), incl. new `KnownHostsTests` (parsing edge cases + config dedup).
- End-to-end checked against a real `~/.ssh`: correctly returns 0 when every `known_hosts` host is already configured, and correctly flags a synthetic host that is not.
- Built + installed the app; SE-dependent setup itself is unchanged (this only adds detection + routing).