### PR TITLE
Security audit fixes (CG-01 … CG-04)

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -561,18 +561,31 @@ final class AppState: ObservableObject {
         }
     }
 
+    /// The `["--", "user@host"]` ssh destination for a candidate, or nil if the user or host
+    /// (possibly parsed from an existing ~/.ssh/config) is unsafe as an ssh argument — a
+    /// leading '-' or any control/whitespace char. Validated right before exec; the `--`
+    /// terminates option parsing as a second line of defense (CG-03).
+    private func sshDestination(_ c: MigrationCandidate) -> [String]? {
+        guard HostSetup.isValidHostToken(c.user), HostSetup.isValidHostToken(c.host) else { return nil }
+        return ["--", "\(c.user)@\(c.host)"]
+    }
+
+    private static let unsafeDestinationMessage =
+        "The username or hostname in ~/.ssh/config contains characters that aren't safe to pass to ssh (a leading “-” or whitespace). Fix the entry and try again."
+
     /// Prove fob works for this host by connecting with ONLY the fob identity (not the
     /// old-key fallback), so a green check means fob specifically succeeded. Touch ID
     /// prompts. Returns nil on success, else an error message.
     func verifyMigration(_ c: MigrationCandidate) async -> String? {
         guard let store else { return "Key store unavailable." }
+        guard let dest = sshDestination(c) else { return Self.unsafeDestinationMessage }
         var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
                     "-o", "StrictHostKeyChecking=accept-new",
                     "-o", "IdentitiesOnly=yes",
                     "-o", "IdentityAgent=\(store.socketPath)",
                     "-i", fobPubURL(c.alias).path]
         if c.port != 22 { args += ["-p", String(c.port)] }
-        args += ["\(c.user)@\(c.host)", "true"]
+        args += dest + ["true"]
         let (status, output) = await runProcess("/usr/bin/ssh", args)
         guard status == 0 else {
             let tail = output.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -649,13 +662,14 @@ final class AppState: ObservableObject {
     /// even when it works). Connects with ONLY the fob identity so a pass means fob.
     func verifyGitHost(_ c: MigrationCandidate) async -> (ok: Bool, message: String) {
         guard let store else { return (false, "Key store unavailable.") }
+        guard let dest = sshDestination(c) else { return (false, Self.unsafeDestinationMessage) }
         var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
                     "-o", "StrictHostKeyChecking=accept-new",
                     "-o", "IdentitiesOnly=yes",
                     "-o", "IdentityAgent=\(store.socketPath)",
                     "-i", fobPubURL(c.alias).path, "-T"]
         if c.port != 22 { args += ["-p", String(c.port)] }
-        args += ["\(c.user)@\(c.host)"]
+        args += dest
         let (_, output) = await runProcess("/usr/bin/ssh", args)
         let greeting = HostSetup.parseSSHGreeting(output)
         if greeting.authenticated {
@@ -1074,6 +1088,7 @@ final class AppState: ObservableObject {
     /// live and nothing has been removed. Handles both servers and git hosts.
     func verifyRotationKey(_ c: MigrationCandidate) async -> (ok: Bool, message: String) {
         guard let store else { return (false, "Key store unavailable.") }
+        guard let dest = sshDestination(c) else { return (false, Self.unsafeDestinationMessage) }
         let tempPub = fobPubURL(rotationTempName(c.alias)).path
         var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
                     "-o", "StrictHostKeyChecking=accept-new",
@@ -1083,7 +1098,7 @@ final class AppState: ObservableObject {
         if c.isGitHost {
             args += ["-T"]
             if c.port != 22 { args += ["-p", String(c.port)] }
-            args += ["\(c.user)@\(c.host)"]
+            args += dest
             let (_, output) = await runProcess("/usr/bin/ssh", args)
             if HostSetup.parseSSHGreeting(output).authenticated {
                 return (true, "New key authenticated with fob — safe to swap.")
@@ -1093,7 +1108,7 @@ final class AppState: ObservableObject {
                 + (tail.isEmpty ? "" : "\n\(tail)"))
         }
         if c.port != 22 { args += ["-p", String(c.port)] }
-        args += ["\(c.user)@\(c.host)", "true"]
+        args += dest + ["true"]
         let (status, output) = await runProcess("/usr/bin/ssh", args)
         guard status == 0 else {
             let tail = output.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -168,7 +168,7 @@ final class AppState: ObservableObject {
         guard let store else { keys = []; return }
         let all = (try? store.all()) ?? []
         keys = all.map { key in
-            let policy = store.policy(name: key.name)
+            let policy = store.displayPolicy(name: key.name)
             // Prefer the alias matching the key name so a key pinned to a shared HostName
             // (github-ousson / github-feedly both → github.com) shows its own alias.
             let names = policy.pinnedHostKeys.map {
@@ -355,7 +355,7 @@ final class AppState: ObservableObject {
             return "“\(host)” isn't in ~/.ssh/known_hosts yet — connect once (ssh \(alias)) first, then pin."
         }
         do {
-            var policy = store.policy(name: alias)
+            var policy = try store.loadPolicyForMutation(name: alias)
             policy.pinnedHostKeys.append(contentsOf: hostKeys.filter { !policy.pinnedHostKeys.contains($0) })
             try store.savePolicy(policy, name: alias)
             refreshKeys()
@@ -951,7 +951,7 @@ final class AppState: ObservableObject {
         return SigningInfo(
             name: name, pubLine: pubLine, pubPath: pubURL.path,
             signerProgram: signer,
-            gitOnly: store.policy(name: name).allowedNamespaces == ["git"])
+            gitOnly: store.displayPolicy(name: name).allowedNamespaces == ["git"])
     }
 
     /// Restrict a key to git-commit signatures only (["git"]), or clear the restriction.
@@ -960,7 +960,7 @@ final class AppState: ObservableObject {
     /// auto-hardening it again; auto-harden passes `explicit: false`.
     func setGitSigningOnly(_ on: Bool, name: String, explicit: Bool = true) {
         run { store in
-            var policy = store.policy(name: name)
+            var policy = try store.loadPolicyForMutation(name: name)
             policy.allowedNamespaces = on ? ["git"] : nil
             if explicit { policy.namespaceChoiceMade = true }
             try store.savePolicy(policy, name: name)
@@ -972,7 +972,9 @@ final class AppState: ObservableObject {
     /// made an explicit namespace choice. Returns the resulting git-only state for the toggle.
     func autoHardenSigningIfEligible(name: String) async -> Bool {
         guard let store else { return false }
-        let policy = store.policy(name: name)
+        // Fail closed: if the policy is unreadable, don't auto-harden (which would write a
+        // fresh policy built on the open default and drop any pins).
+        guard let policy = try? store.loadPolicyForMutation(name: name) else { return false }
         let signingOnly = await keyUsage(name: name).authHosts.isEmpty
         if policy.shouldAutoHardenSigning(isSigningOnly: signingOnly) {
             setGitSigningOnly(true, name: name, explicit: false)
@@ -1117,7 +1119,7 @@ final class AppState: ObservableObject {
         // carried onto the new line. nil ⟹ auth-only key, so we don't touch allowed_signers.
         let signingEmail = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
         do {
-            copyPolicy(from: name, to: temp)               // new key inherits pin/reuse/namespaces
+            try copyPolicy(from: name, to: temp)           // new key inherits pin/reuse/namespaces
             try store.rename(from: name, to: retired)      // move old aside (recoverable)
             try store.rename(from: temp, to: name)         // new key takes the name
             try store.remove(name: retired)                // destroy the old enclave key
@@ -1148,9 +1150,12 @@ final class AppState: ObservableObject {
     }
 
     /// Copy a key's whole policy (pin/reuse/namespaces + choice marker) to another name.
-    private func copyPolicy(from: String, to: String) {
+    /// Throws (fail closed) if the source policy is unreadable, so rotation can't silently
+    /// hand the new key an open default and drop the old key's pins.
+    private func copyPolicy(from: String, to: String) throws {
         guard let store else { return }
-        try? store.savePolicy(store.policy(name: from), name: to)
+        let policy = try store.loadPolicyForMutation(name: from)
+        try store.savePolicy(policy, name: to)
     }
 
     /// Append an entry to ~/.ssh/allowed_signers (idempotent) so signed commits verify locally.
@@ -1207,7 +1212,7 @@ final class AppState: ObservableObject {
 
     func unpin(name: String) {
         run { store in
-            var policy = store.policy(name: name)
+            var policy = try store.loadPolicyForMutation(name: name)
             policy.pinnedHostKeys = []
             try store.savePolicy(policy, name: name)
         }
@@ -1269,7 +1274,7 @@ final class AppState: ObservableObject {
                     + "must be known first. Connect to it once — e.g. `ssh \(host)` "
                     + "and accept the prompt — or run `fob setup \(host)`. Then pin again.")
             }
-            var policy = store.policy(name: name)
+            var policy = try store.loadPolicyForMutation(name: name)
             policy.pinnedHostKeys.append(contentsOf: hostKeys.filter { !policy.pinnedHostKeys.contains($0) })
             try store.savePolicy(policy, name: name)
         }
@@ -1277,7 +1282,7 @@ final class AppState: ObservableObject {
 
     func setReuse(name: String, seconds: Int) {
         run { store in
-            var policy = store.policy(name: name)
+            var policy = try store.loadPolicyForMutation(name: name)
             policy.reuseSeconds = seconds > 0 ? Double(min(seconds, 300)) : nil
             try store.savePolicy(policy, name: name)
         }

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -570,6 +570,23 @@ final class AppState: ObservableObject {
         return ["--", "\(c.user)@\(c.host)"]
     }
 
+    /// Does this host already have a key in known_hosts? When it does, a verify connects
+    /// with StrictHostKeyChecking=yes (reject a changed/MITM key) instead of trusting on
+    /// first use; when it doesn't, the connection is genuinely first-use (TOFU), which the
+    /// UI labels honestly rather than presenting as verified identity (CG-04).
+    func hostIsKnown(_ c: MigrationCandidate) -> Bool {
+        !HostResolver.knownHostKeys(for: c.host, port: c.port == 22 ? nil : c.port).isEmpty
+    }
+
+    private func strictHostKeyOption(_ c: MigrationCandidate) -> String {
+        "StrictHostKeyChecking=" + (hostIsKnown(c) ? "yes" : "accept-new")
+    }
+
+    /// The `SHA256:…` fingerprint of the host's current known_hosts key, for a TOFU caution.
+    func hostKeyFingerprint(_ c: MigrationCandidate) -> String? {
+        HostResolver.fingerprint(forHost: c.host, port: c.port == 22 ? nil : c.port)
+    }
+
     private static let unsafeDestinationMessage =
         "The username or hostname in ~/.ssh/config contains characters that aren't safe to pass to ssh (a leading “-” or whitespace). Fix the entry and try again."
 
@@ -580,7 +597,7 @@ final class AppState: ObservableObject {
         guard let store else { return "Key store unavailable." }
         guard let dest = sshDestination(c) else { return Self.unsafeDestinationMessage }
         var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
-                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", strictHostKeyOption(c),
                     "-o", "IdentitiesOnly=yes",
                     "-o", "IdentityAgent=\(store.socketPath)",
                     "-i", fobPubURL(c.alias).path]
@@ -664,7 +681,7 @@ final class AppState: ObservableObject {
         guard let store else { return (false, "Key store unavailable.") }
         guard let dest = sshDestination(c) else { return (false, Self.unsafeDestinationMessage) }
         var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
-                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", strictHostKeyOption(c),
                     "-o", "IdentitiesOnly=yes",
                     "-o", "IdentityAgent=\(store.socketPath)",
                     "-i", fobPubURL(c.alias).path, "-T"]
@@ -1091,7 +1108,7 @@ final class AppState: ObservableObject {
         guard let dest = sshDestination(c) else { return (false, Self.unsafeDestinationMessage) }
         let tempPub = fobPubURL(rotationTempName(c.alias)).path
         var args = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10",
-                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", strictHostKeyOption(c),
                     "-o", "IdentitiesOnly=yes",
                     "-o", "IdentityAgent=\(store.socketPath)",
                     "-i", tempPub]

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -413,6 +413,7 @@ struct ContentView: View {
         case .refusedPin:    return (e.key ?? "key", "\(act) · blocked (wrong host)")
         case .refusedPolicy: return (e.key ?? "key", "\(act) · blocked (policy)")
         case .refusedNamespace: return (e.key ?? "key", "\(act) · blocked (namespace)")
+        case .refusedMalformed: return (e.key ?? "key", "\(act) · blocked (malformed)")
         case .unknownKey:    return (peerCmd(e.peer) ?? "unknown", (dest.map { " · \($0)" } ?? "") + " · unknown key")
         case .bind:          return (dest ?? "host", " · bound")
         case .bindRejected:  return (peerCmd(e.peer) ?? "client", " · bind rejected")
@@ -446,7 +447,7 @@ struct ContentView: View {
         switch kind {
         case .signed, .signedReused: return Theme.green
         case .denied: return .orange
-        case .refusedPin, .refusedPolicy, .refusedNamespace, .bindRejected: return Theme.red
+        case .refusedPin, .refusedPolicy, .refusedNamespace, .refusedMalformed, .bindRejected: return Theme.red
         case .unknownKey: return .yellow
         case .bind: return Theme.accent
         case .listening: return t.sub

--- a/Sources/FobApp/MigrateHostView.swift
+++ b/Sources/FobApp/MigrateHostView.swift
@@ -22,6 +22,7 @@ struct MigrateHostView: View {
     @State private var verified: Status?
     @State private var pinned = false
     @State private var pinNote: String?
+    @State private var firstUse = false   // host wasn't in known_hosts before verify (TOFU)
     @State private var retired: Status?
 
     // Git-host flow state.
@@ -151,6 +152,11 @@ struct MigrateHostView: View {
         // Step 4 — pin + retire + sign hop
         if verified?.ok == true {
             step(4, "Lock it down") {
+                if firstUse, !pinned, let fp = state.hostKeyFingerprint(c) {
+                    Label("First connection to \(c.host) — its host key was trusted on first use, not verified. If this host is security-sensitive, confirm this fingerprint against a trusted source before pinning:\n\(fp)",
+                          systemImage: "exclamationmark.shield")
+                        .font(.caption).foregroundStyle(.orange).fixedSize(horizontal: false, vertical: true)
+                }
                 HStack(spacing: 10) {
                     Button(pinned ? "Pinned ✓" : "Pin \(alias) → \(c.host)") { runPin(c) }.disabled(pinned)
                     if let pinNote {
@@ -230,6 +236,7 @@ struct MigrateHostView: View {
     }
 
     private func runVerifyGit(_ c: AppState.MigrationCandidate) {
+        firstUse = !state.hostIsKnown(c)   // capture before the connection trusts it (accept-new)
         busy = true
         Task {
             let result = await state.verifyGitHost(c)
@@ -397,6 +404,7 @@ struct MigrateHostView: View {
     }
 
     private func runVerify(_ c: AppState.MigrationCandidate) {
+        firstUse = !state.hostIsKnown(c)   // capture before the connection trusts it (accept-new)
         busy = true
         Task {
             if let msg = await state.verifyMigration(c) {

--- a/Sources/FobKit/Agent.swift
+++ b/Sources/FobKit/Agent.swift
@@ -18,7 +18,7 @@ private enum AgentMessage: UInt8 {
 /// flows through here so the menu-bar app can show a live feed.
 public struct AgentEvent {
     public enum Kind: String {
-        case listening, signed, signedReused, denied, refusedPin, refusedPolicy, refusedNamespace, unknownKey, bind, bindRejected
+        case listening, signed, signedReused, denied, refusedPin, refusedPolicy, refusedNamespace, refusedMalformed, unknownKey, bind, bindRejected
     }
     public let kind: Kind
     public let message: String
@@ -275,9 +275,20 @@ public final class Agent: @unchecked Sendable {
 
         // A commit/file signature (`ssh-keygen -Y sign`, e.g. git commit signing) rather
         // than an SSH login: the payload is an SSHSIG envelope. It has no host binding,
-        // so it's gated by the key's allowed namespaces, not by host pinning.
-        if let namespace = SSHSIG.namespace(of: dataToSign) {
-            return signSSHSIG(key: key, data: dataToSign, namespace: namespace, policy: policy, peer: peer)
+        // so it's gated by the key's allowed namespaces, not by host pinning. Parse it
+        // strictly: an envelope that carries the "SSHSIG" magic but doesn't conform is
+        // refused (never signed under a misleading label, never fell through to auth).
+        switch SSHSIG.classify(dataToSign) {
+        case .valid(let parsed):
+            return signSSHSIG(key: key, data: dataToSign, namespace: parsed.namespace, policy: policy, peer: peer)
+        case .malformed:
+            log("REFUSED key '\(key.name)' (\(peer)) — malformed SSHSIG signing request")
+            audit.record("refused-malformed", key: key.name, destination: "sshsig", peer: peer)
+            announce(.refusedMalformed, "⛔️ Blocked: \(peer) sent a malformed signature request with key '\(key.name)'",
+                     key: key.name, destination: "sshsig", peer: peer)
+            return Data([AgentMessage.failure.rawValue])
+        case .notSSHSIG:
+            break // an ordinary SSH authentication payload — continue below
         }
 
         // Pinning: a pinned key signs only for its verified, bound host — refused
@@ -344,12 +355,16 @@ public final class Agent: @unchecked Sendable {
     /// auth, nor across namespaces).
     private func signSSHSIG(key: StoredKey, data: Data, namespace: String,
                             policy: KeyPolicy, peer: String) -> Data {
-        let purpose = namespace == "git" ? "a git commit" : "a \(namespace) signature"
+        // The raw namespace drives the policy check; a sanitized copy (control chars
+        // stripped, length-capped) is what goes into prompts, notifications, and audit —
+        // so a crafted namespace can't inject newlines/escapes into that text.
+        let safeNS = Self.sanitizeNamespace(namespace)
+        let purpose = namespace == "git" ? "a git commit" : "a \(safeNS) signature"
         guard policy.allowsSignature(namespace: namespace) else {
-            log("REFUSED signing \(purpose) with key '\(key.name)' (\(peer)) — namespace '\(namespace)' not allowed")
-            audit.record("refused-namespace", key: key.name, destination: namespace, peer: peer)
-            announce(.refusedNamespace, "⛔️ Blocked: \(peer) tried to sign \(purpose) with key '\(key.name)' — namespace ‘\(namespace)’ isn't allowed",
-                     key: key.name, destination: namespace, peer: peer)
+            log("REFUSED signing \(purpose) with key '\(key.name)' (\(peer)) — namespace '\(safeNS)' not allowed")
+            audit.record("refused-namespace", key: key.name, destination: safeNS, peer: peer)
+            announce(.refusedNamespace, "⛔️ Blocked: \(peer) tried to sign \(purpose) with key '\(key.name)' — namespace ‘\(safeNS)’ isn't allowed",
+                     key: key.name, destination: safeNS, peer: peer)
             return Data([AgentMessage.failure.rawValue])
         }
 
@@ -359,7 +374,7 @@ public final class Agent: @unchecked Sendable {
         if reuseWindow > 0, let cached = cachedAuthorization(for: key.name, destination: reuseScope) {
             if let signature = try? key.privateKey(context: cached).signature(for: data) {
                 log("signed \(purpose) with key '\(key.name)' (\(peer)) — reuse window")
-                audit.record("signed-\(namespace)", key: key.name, destination: purpose, peer: peer)
+                audit.record("signed-\(safeNS)", key: key.name, destination: purpose, peer: peer)
                 announce(.signedReused, "🔑 \(peer) signed \(purpose) with key '\(key.name)' (reuse window)",
                          key: key.name, destination: purpose, peer: peer)
                 return signResponse(signature)
@@ -387,6 +402,14 @@ public final class Agent: @unchecked Sendable {
                      key: key.name, destination: purpose, peer: peer)
             return Data([AgentMessage.failure.rawValue])
         }
+    }
+
+    /// Strip control characters (and cap length) from an SSHSIG namespace before it's shown
+    /// in a Touch ID prompt / notification / audit event — a validated namespace is still
+    /// attacker-chosen text, so it must never carry newlines or escapes into that display.
+    static func sanitizeNamespace(_ s: String) -> String {
+        let cleaned = String(s.unicodeScalars.filter { !CharacterSet.controlCharacters.contains($0) })
+        return String(cleaned.prefix(64))
     }
 
     private func signResponse(_ signature: P256.Signing.ECDSASignature) -> Data {

--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -25,10 +25,15 @@ public enum HostSetup {
         return false
     }
 
-    /// A hostname/username safe to interpolate into ssh arguments and config: non-empty,
-    /// no spaces, and no leading '-' (so it can never be parsed as an ssh option).
+    /// A hostname/username safe to interpolate into ssh arguments and config: non-empty, no
+    /// leading '-' (so it can never be parsed as an ssh option such as `-oProxyCommand=…`),
+    /// and no ASCII control or whitespace character (space, tab, newline, …) — not just the
+    /// literal space. Applied to values parsed from an existing ~/.ssh/config too, right
+    /// before they become ssh arguments.
     public static func isValidHostToken(_ s: String) -> Bool {
-        !s.isEmpty && !s.contains(" ") && !s.hasPrefix("-")
+        guard !s.isEmpty, !s.hasPrefix("-") else { return false }
+        let unsafe = CharacterSet.whitespacesAndNewlines.union(.controlCharacters)
+        return s.unicodeScalars.allSatisfy { !unsafe.contains($0) }
     }
 
     /// POSIX single-quote a string so a shell treats it as one literal argument, safe to

--- a/Sources/FobKit/KeyPolicy.swift
+++ b/Sources/FobKit/KeyPolicy.swift
@@ -121,6 +121,19 @@ extension HostResolver {
         return hostKeys(inKnownHosts: contents, host: host, port: port)
     }
 
+    /// The OpenSSH-style `SHA256:…` fingerprint of a host key blob (base64, no padding) —
+    /// the same form `ssh` prints on a first connection, so a user can compare it against a
+    /// trusted source before pinning a trust-on-first-use host (CG-04).
+    public static func fingerprint(ofHostKey blob: Data) -> String {
+        "SHA256:" + Data(SHA256.hash(data: blob)).base64EncodedString()
+            .trimmingCharacters(in: CharacterSet(charactersIn: "="))
+    }
+
+    /// The fingerprint of the host's first recorded known_hosts key, or nil if none.
+    public static func fingerprint(forHost host: String, port: Int? = nil) -> String? {
+        knownHostKeys(for: host, port: port).first.map(fingerprint(ofHostKey:))
+    }
+
     /// Pure matcher over known_hosts contents (testable without touching the filesystem).
     static func hostKeys(inKnownHosts contents: String, host: String, port: Int?) -> [Data] {
         var blobs: [Data] = []

--- a/Sources/FobKit/KeyPolicy.swift
+++ b/Sources/FobKit/KeyPolicy.swift
@@ -76,11 +76,26 @@ extension KeyStore {
         }
     }
 
-    /// Convenience for display contexts (CLI/UI): an unreadable policy shows as the
-    /// default. Signing decisions MUST use `policyStatus` so corruption fails closed.
-    public func policy(name: String) -> KeyPolicy {
+    /// Convenience for **display** contexts only (CLI/UI): an unreadable policy shows as
+    /// the default. Signing decisions MUST use `policyStatus`, and any read-modify-write
+    /// MUST use `loadPolicyForMutation`, so corruption fails closed instead of silently
+    /// rewriting the record without its pins.
+    public func displayPolicy(name: String) -> KeyPolicy {
         if case .present(let policy) = policyStatus(name: name) { return policy }
         return KeyPolicy()
+    }
+
+    /// Load a policy for a read-modify-write. `.absent` is the open default (there is
+    /// genuinely no record yet); `.unreadable` **throws** so a mutation can't overwrite a
+    /// corrupt/transiently-unreadable record with a partial policy built on the open
+    /// default (which would drop pins / a namespace restriction). Callers must surface the
+    /// error and leave the record untouched.
+    public func loadPolicyForMutation(name: String) throws -> KeyPolicy {
+        switch policyStatus(name: name) {
+        case .present(let policy): return policy
+        case .absent: return KeyPolicy()
+        case .unreadable: throw KeyStoreError.policyUnreadable(name)
+        }
     }
 
     public func savePolicy(_ policy: KeyPolicy, name: String) throws {

--- a/Sources/FobKit/KeyStore.swift
+++ b/Sources/FobKit/KeyStore.swift
@@ -218,15 +218,27 @@ public struct KeyStore {
         let toKey = keysDirectory.appendingPathComponent("\(to).key")
         guard fm.fileExists(atPath: fromKey.path) else { throw KeyStoreError.notFound(from) }
         guard !fm.fileExists(atPath: toKey.path) else { throw KeyStoreError.keyExists(to) }
-        // Move the (opaque) enclave blob.
+
+        // Load the policy BEFORE moving anything: an unreadable policy throws here (via
+        // load), so we never leave a key renamed with its pins silently dropped. `nil`
+        // means genuinely no record (open) — nothing to migrate.
+        let policy = try policyStore.load(name: from)
+
+        // Move the (opaque) enclave blob, then migrate the policy transactionally: on any
+        // failure, move the blob back and rethrow so name and policy stay in lock-step.
         try fm.moveItem(at: fromKey, to: toKey)
-        // Migrate the policy through the store (handles both file- and keychain-backed).
-        if let policy = try? policyStore.load(name: from) {
-            try policyStore.save(policy, name: to)
+        do {
+            if let policy { try policyStore.save(policy, name: to) }
             try policyStore.remove(name: from)
+        } catch {
+            try? policyStore.remove(name: to)          // undo a partial policy write
+            try? fm.moveItem(at: toKey, to: fromKey)   // undo the blob move
+            throw error
         }
+
         // Move the in-store public key, retargeting its `fob:<name>` comment textually — the
-        // base64 blob is unchanged, so no enclave access is needed.
+        // base64 blob is unchanged, so no enclave access is needed. Cosmetic vs. the security
+        // record above, so a failure here doesn't roll back the (already consistent) rename.
         let fromPub = keysDirectory.appendingPathComponent("\(from).pub")
         if let text = try? String(contentsOf: fromPub, encoding: .utf8) {
             let rewritten = text.replacingOccurrences(of: "fob:\(from)", with: "fob:\(to)")
@@ -243,6 +255,7 @@ public enum KeyStoreError: LocalizedError {
     case keyExists(String)
     case notFound(String)
     case invalidName(String)
+    case policyUnreadable(String)
 
     public var errorDescription: String? {
         switch self {
@@ -256,6 +269,8 @@ public enum KeyStoreError: LocalizedError {
             return "no key named '\(name)'"
         case .invalidName(let name):
             return "invalid key name '\(name)' (letters, digits, '.', '_', '-'; must not start with '-')"
+        case .policyUnreadable(let name):
+            return "the policy for '\(name)' is unreadable — refusing to change it until that's fixed, so its pins aren't silently dropped"
         }
     }
 }

--- a/Sources/FobKit/SSHWire.swift
+++ b/Sources/FobKit/SSHWire.swift
@@ -106,18 +106,53 @@ public enum SSHFormat {
 }
 
 /// The SSHSIG signing envelope (`ssh-keygen -Y sign`, which is how git signs commits).
-/// The blob handed to the agent starts with the literal magic "SSHSIG" followed by a
-/// namespace string ("git" for commits) — letting the agent tell a *signature*
-/// operation apart from an SSH *authentication* and label / gate it accordingly.
+/// The blob handed to the agent is the signed-data structure from PROTOCOL.sshsig:
+///
+///     "SSHSIG"  string namespace  string reserved
+///     string hash_algorithm  string H(message)
+///
+/// The magic + namespace exist to keep an SSHSIG signature from being usable in another
+/// protocol (domain separation). We therefore parse it *strictly*: a blob that carries
+/// the magic but doesn't conform is treated as malformed and refused — never signed under
+/// a misleading "git commit" label, and never allowed to fall through to the SSH-auth path.
 enum SSHSIG {
     static let magic = Data("SSHSIG".utf8)
 
-    /// The namespace of an SSHSIG blob, or nil if `data` isn't one (e.g. it's an
-    /// ordinary SSH authentication payload, which never starts with this magic).
-    static func namespace(of data: Data) -> String? {
-        guard data.count > magic.count, data.prefix(magic.count) == magic else { return nil }
+    struct Parsed: Equatable {
+        let namespace: String
+        let hashAlgorithm: String // "sha256" or "sha512"
+    }
+
+    /// The result of inspecting a to-be-signed blob.
+    enum Classification: Equatable {
+        case notSSHSIG          // no magic → an ordinary SSH authentication payload
+        case malformed          // magic present but the envelope is invalid → refuse
+        case valid(Parsed)      // a well-formed SSHSIG envelope → sign, gated by namespace
+    }
+
+    /// Digest sizes per hash algorithm (SHA-256 → 32 bytes, SHA-512 → 64).
+    private static let digestSize = ["sha256": 32, "sha512": 64]
+
+    /// Strictly classify `data`. Requires, after the magic: a non-empty valid-UTF-8
+    /// namespace, a `reserved` string, `hash_algorithm ∈ {sha256, sha512}`, an `H(message)`
+    /// whose length matches that algorithm, and no trailing bytes.
+    static func classify(_ data: Data) -> Classification {
+        guard data.count >= magic.count, data.prefix(magic.count) == magic else { return .notSSHSIG }
         var reader = SSHReader(Data(data.dropFirst(magic.count)))
-        guard let namespace = try? reader.readString() else { return nil }
-        return String(decoding: namespace, as: UTF8.self)
+        do {
+            let namespaceData = try reader.readString()
+            guard !namespaceData.isEmpty,
+                  let namespace = String(bytes: namespaceData, encoding: .utf8) else { return .malformed }
+            _ = try reader.readString() // reserved (any value, typically empty)
+            let algoData = try reader.readString()
+            guard let algo = String(bytes: algoData, encoding: .utf8),
+                  let wantDigest = digestSize[algo] else { return .malformed }
+            let digest = try reader.readString()
+            guard digest.count == wantDigest else { return .malformed }
+            guard reader.isAtEnd else { return .malformed } // reject trailing bytes
+            return .valid(Parsed(namespace: namespace, hashAlgorithm: algo))
+        } catch {
+            return .malformed
+        }
     }
 }

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -137,7 +137,7 @@ enum Setup {
         if hostKeys.isEmpty {
             print("Not in known_hosts yet — pin later with: fob pin \(alias) \(host)")
         } else {
-            var policy = store.policy(name: alias)
+            var policy = try store.loadPolicyForMutation(name: alias)
             policy.pinnedHostKeys.append(contentsOf: hostKeys.filter { !policy.pinnedHostKeys.contains($0) })
             try store.savePolicy(policy, name: alias)
             print("🔒 Pinned \(alias) to \(host) — undo with: fob unpin \(alias)")
@@ -378,7 +378,7 @@ enum Setup {
             print("Pin it later with: fob pin \(alias) \(host)")
             return
         }
-        var policy = store.policy(name: alias)
+        var policy = try store.loadPolicyForMutation(name: alias)
         policy.pinnedHostKeys.append(contentsOf: hostKeys.filter { !policy.pinnedHostKeys.contains($0) })
         try store.savePolicy(policy, name: alias)
         print("🔒 Key '\(alias)' pinned to \(host): the agent will refuse it for any other")

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -32,6 +32,11 @@ enum Setup {
         let old = parsed.identityFiles.first(where: { !$0.contains("/fob_") })
         let isGitProvider = HostSetup.isGitHost(hostName: host, user: user)
         let settingsURL = HostSetup.sshKeySettingsURL(forHost: host)
+        // Values parsed from an existing ~/.ssh/config are revalidated before they can
+        // become ssh arguments — a leading '-' or whitespace would otherwise be parsed as
+        // an ssh option (CG-03).
+        guard HostSetup.isValidHostToken(host) else { throw SetupError.invalidHost(host) }
+        guard HostSetup.isValidHostToken(user) else { throw SetupError.invalidUser(user) }
 
         // `--retire`: just comment out the old IdentityFile (run after a verified migration).
         if retire {
@@ -123,7 +128,7 @@ enum Setup {
         } else if confirm("Test the connection now? (Touch ID will prompt)") {
             let args = ["-o", "ConnectTimeout=10", "-o", "IdentitiesOnly=yes",
                         "-o", "IdentityAgent=\(store.socketPath)", "-i", pubURL.path]
-                + portArg + ["\(user)@\(host)", "true"]
+                + portArg + ["--", "\(user)@\(host)", "true"]
             if runInteractive("/usr/bin/ssh", args) == 0 {
                 print("✅ fob works for \(alias). Your old key is still a fallback.")
             } else {
@@ -361,7 +366,7 @@ enum Setup {
             : ["-o", "ConnectTimeout=10",
                "-o", "IdentityAgent=\(store.socketPath)",
                "-o", "IdentitiesOnly=yes",
-               "-i", pubURL.path, destination, "true"]
+               "-i", pubURL.path, "--", destination, "true"]
         if runInteractive("/usr/bin/ssh", sshArgs) == 0 {
             print("")
             print("✅ \(destination) accepted the Secure Enclave key. You're all set\(aliasConfigured ? ": ssh \(alias)" : ".")")

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -352,7 +352,7 @@ do {
         guard !hostKeys.isEmpty else {
             fail("no host keys for '\(host)' in ~/.ssh/known_hosts — connect once (ssh \(host)) and retry")
         }
-        var policy = store.policy(name: key.name)
+        var policy = try store.loadPolicyForMutation(name: key.name)
         let added = hostKeys.filter { !policy.pinnedHostKeys.contains($0) }
         policy.pinnedHostKeys.append(contentsOf: added)
         try store.savePolicy(policy, name: key.name)
@@ -365,7 +365,7 @@ do {
             fail("usage: fob unpin <name>")
         }
         let key = try store.find(name: name)
-        var policy = store.policy(name: key.name)
+        var policy = try store.loadPolicyForMutation(name: key.name)
         policy.pinnedHostKeys = []
         try store.savePolicy(policy, name: key.name)
         print("Removed all pins from key '\(key.name)'.")
@@ -374,7 +374,7 @@ do {
         let rest = Array(arguments.dropFirst())
         guard rest.count == 2 else { fail("usage: fob reuse <name> <seconds|off>") }
         let key = try store.find(name: rest[0])
-        var policy = store.policy(name: key.name)
+        var policy = try store.loadPolicyForMutation(name: key.name)
         if rest[1] == "off" {
             policy.reuseSeconds = nil
             try store.savePolicy(policy, name: key.name)
@@ -392,7 +392,7 @@ do {
         let rest = Array(arguments.dropFirst())
         guard rest.count == 2 else { fail("usage: fob namespaces <name> <any|none|ns1,ns2,...>") }
         let key = try store.find(name: rest[0])
-        var policy = store.policy(name: key.name)
+        var policy = try store.loadPolicyForMutation(name: key.name)
         switch rest[1].lowercased() {
         case "any": policy.allowedNamespaces = nil
         case "none": policy.allowedNamespaces = []
@@ -516,7 +516,7 @@ do {
             // A fob:<name> allowed_signers line ⟺ signing key; carry its principal. nil ⟹ auth-
             // only, so don't touch allowed_signers (avoids adding a spurious line).
             let signingEmail = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
-            try store.savePolicy(store.policy(name: name), name: temp) // carry pin/reuse/namespaces
+            try store.savePolicy(try store.loadPolicyForMutation(name: name), name: temp) // carry pin/reuse/namespaces (fail closed)
             try store.rename(from: name, to: "\(name).retired")        // old aside (recoverable)
             try store.rename(from: temp, to: name)                     // new takes the name
             try store.remove(name: "\(name).retired")                  // destroy the old key
@@ -541,7 +541,7 @@ do {
         let keys = try store.all()
         if keys.isEmpty { print("No keys yet.") }
         for key in keys {
-            let policy = store.policy(name: key.name)
+            let policy = store.displayPolicy(name: key.name)
             var parts: [String] = []
             if policy.pinnedHostKeys.isEmpty {
                 parts.append("not pinned (any destination)")

--- a/Tests/FobKitTests/HostSetupTests.swift
+++ b/Tests/FobKitTests/HostSetupTests.swift
@@ -3,6 +3,23 @@ import XCTest
 @testable import FobKit
 
 final class HostSetupTests: XCTestCase {
+    func testIsValidHostTokenRejectsOptionAndWhitespaceInjection() {
+        // Valid tokens.
+        XCTAssertTrue(HostSetup.isValidHostToken("example.com"))
+        XCTAssertTrue(HostSetup.isValidHostToken("git"))
+        XCTAssertTrue(HostSetup.isValidHostToken("192.168.1.10"))
+        XCTAssertTrue(HostSetup.isValidHostToken("user_1"))
+        // Leading dash → would be parsed as an ssh option.
+        XCTAssertFalse(HostSetup.isValidHostToken("-oProxyCommand=evil"))
+        XCTAssertFalse(HostSetup.isValidHostToken("-"))
+        // Whitespace/control — space, tab, newline (not just the literal space).
+        XCTAssertFalse(HostSetup.isValidHostToken("a b"))
+        XCTAssertFalse(HostSetup.isValidHostToken("a\tb"))
+        XCTAssertFalse(HostSetup.isValidHostToken("a\nProxyCommand x"))
+        XCTAssertFalse(HostSetup.isValidHostToken("a\r"))
+        XCTAssertFalse(HostSetup.isValidHostToken(""))
+    }
+
     func testConfigBlockOmitsDefaultPort() {
         let block = HostSetup.configBlock(alias: "web", host: "h.example", user: "u",
                                           pubPath: "/p.pub", socketPath: "/s.sock")

--- a/Tests/FobKitTests/HostSetupTests.swift
+++ b/Tests/FobKitTests/HostSetupTests.swift
@@ -65,6 +65,12 @@ final class HostSetupTests: XCTestCase {
         XCTAssertEqual(blobs("192.168.1.9", 22).count, 1)
     }
 
+    func testHostKeyFingerprintFormat() {
+        // Known SHA-256 of the ASCII bytes "abc" → base64, no padding, "SHA256:" prefix.
+        let fp = HostResolver.fingerprint(ofHostKey: Data("abc".utf8))
+        XCTAssertEqual(fp, "SHA256:ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0")
+    }
+
     func testParseHostBlock() {
         let cfg = """
         Host web

--- a/Tests/FobKitTests/PolicyMutationTests.swift
+++ b/Tests/FobKitTests/PolicyMutationTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import XCTest
+
+@testable import FobKit
+
+/// A PolicyStore whose `load`/`save` can be made to throw, to prove that policy-mutating
+/// paths fail closed (never overwrite an unreadable record with the open default) and that
+/// `rename` is transactional (CG-02).
+private struct FaultyPolicyStore: PolicyStore {
+    var loadError: Error?
+    var saveError: Error?
+    var loadResult: KeyPolicy? = KeyPolicy()
+
+    func load(name: String) throws -> KeyPolicy? {
+        if let loadError { throw loadError }
+        return loadResult
+    }
+    func save(_ policy: KeyPolicy, name: String) throws {
+        if let saveError { throw saveError }
+    }
+    func remove(name: String) throws {}
+}
+
+final class PolicyMutationTests: XCTestCase {
+    private func tempStore(_ ps: PolicyStore) throws -> (KeyStore, URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fob-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir.appendingPathComponent("keys"), withIntermediateDirectories: true)
+        return (KeyStore(directory: dir, policyStore: ps), dir)
+    }
+
+    // loadPolicyForMutation must THROW when the policy is unreadable (so a mutation can't
+    // rebuild it on the open default), while displayPolicy still shows the default.
+    func testMutationLoadFailsClosedButDisplayDefaults() throws {
+        let (store, dir) = try tempStore(FaultyPolicyStore(loadError: PolicyStoreError.decode))
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        XCTAssertThrowsError(try store.loadPolicyForMutation(name: "k")) { error in
+            guard case KeyStoreError.policyUnreadable = error else {
+                return XCTFail("expected .policyUnreadable, got \(error)")
+            }
+        }
+        XCTAssertTrue(store.displayPolicy(name: "k").isDefault, "display still falls back to open default")
+    }
+
+    // absent (no record) is the open default — a mutation may proceed from it.
+    func testMutationLoadTreatsAbsentAsDefault() throws {
+        let (store, dir) = try tempStore(FaultyPolicyStore(loadResult: nil))
+        defer { try? FileManager.default.removeItem(at: dir) }
+        XCTAssertTrue(try store.loadPolicyForMutation(name: "k").isDefault)
+    }
+
+    // rename fails closed on an unreadable policy: it throws BEFORE moving the key blob,
+    // so the key keeps its old name (never renamed without its policy).
+    func testRenameFailsClosedOnUnreadablePolicy() throws {
+        let (store, dir) = try tempStore(FaultyPolicyStore(loadError: PolicyStoreError.decode))
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let keys = dir.appendingPathComponent("keys")
+        try Data("blob".utf8).write(to: keys.appendingPathComponent("from.key"))
+
+        XCTAssertThrowsError(try store.rename(from: "from", to: "to"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: keys.appendingPathComponent("from.key").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: keys.appendingPathComponent("to.key").path))
+    }
+
+    // rename rolls back the key-blob move if the policy save fails midway — the key stays
+    // under its original name, not stranded under the new name with no policy.
+    func testRenameRollsBackWhenPolicySaveFails() throws {
+        let (store, dir) = try tempStore(FaultyPolicyStore(saveError: PolicyStoreError.decode))
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let keys = dir.appendingPathComponent("keys")
+        try Data("blob".utf8).write(to: keys.appendingPathComponent("from.key"))
+
+        XCTAssertThrowsError(try store.rename(from: "from", to: "to"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: keys.appendingPathComponent("from.key").path),
+                      "blob rolled back to original name")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: keys.appendingPathComponent("to.key").path))
+    }
+}

--- a/Tests/FobKitTests/PolicyStoreTests.swift
+++ b/Tests/FobKitTests/PolicyStoreTests.swift
@@ -54,7 +54,7 @@ final class PolicyStoreTests: XCTestCase {
             return XCTFail("a throwing store must surface as .unreadable (fail closed)")
         }
         // Display convenience still degrades to the open default.
-        XCTAssertTrue(store.policy(name: "k").pinnedHostKeys.isEmpty)
+        XCTAssertTrue(store.displayPolicy(name: "k").pinnedHostKeys.isEmpty)
     }
 
     func testSavePolicyStoresAndDefaultRemoves() throws {
@@ -110,8 +110,8 @@ final class PolicyStoreTests: XCTestCase {
         // User unticks git-only on a signing-only key: allowedNamespaces nil BUT choice made.
         try store.savePolicy(KeyPolicy(namespaceChoiceMade: true), name: "k")
         // It must persist (not be dropped as "default") so it isn't re-hardened later.
-        XCTAssertEqual(store.policy(name: "k").namespaceChoiceMade, true)
-        XCTAssertFalse(store.policy(name: "k").shouldAutoHardenSigning(isSigningOnly: true))
+        XCTAssertEqual(store.displayPolicy(name: "k").namespaceChoiceMade, true)
+        XCTAssertFalse(store.displayPolicy(name: "k").shouldAutoHardenSigning(isSigningOnly: true))
     }
 
     // MARK: - Keychain availability probe is safe on any build

--- a/Tests/FobKitTests/SecurityTests.swift
+++ b/Tests/FobKitTests/SecurityTests.swift
@@ -169,7 +169,7 @@ final class SecurityTests: XCTestCase {
         let policyURL = store.keysDirectory.appendingPathComponent("\(name).policy")
         try Data("this is not json".utf8).write(to: policyURL)
         assertPolicy(.unreadable, store.policyStatus(name: name))
-        XCTAssertTrue(store.policy(name: name).pinnedHostKeys.isEmpty, "display fallback is default")
+        XCTAssertTrue(store.displayPolicy(name: name).pinnedHostKeys.isEmpty, "display fallback is default")
     }
 
     // MARK: - Audit hash chain tamper-evidence
@@ -231,9 +231,9 @@ final class SecurityTests: XCTestCase {
         XCTAssertTrue(pub.contains("fob:rot2"))            // comment retargeted
         XCTAssertFalse(pub.contains("fob:rot\n"))          // old exact comment gone
         XCTAssertTrue(pub.contains("AAAABBB"))             // same blob preserved
-        XCTAssertEqual(store.policy(name: "rot2").reuseSeconds, 30)          // policy carried over
-        XCTAssertEqual(store.policy(name: "rot2").namespaceChoiceMade, true)
-        XCTAssertTrue(store.policy(name: "rot").isDefault)                   // old policy cleared
+        XCTAssertEqual(store.displayPolicy(name: "rot2").reuseSeconds, 30)          // policy carried over
+        XCTAssertEqual(store.displayPolicy(name: "rot2").namespaceChoiceMade, true)
+        XCTAssertTrue(store.displayPolicy(name: "rot").isDefault)                   // old policy cleared
 
         XCTAssertThrowsError(try store.rename(from: "absent", to: "x"))      // source missing
         try Data("x".utf8).write(to: dir.appendingPathComponent("occupied.key"))

--- a/Tests/FobKitTests/SigningTests.swift
+++ b/Tests/FobKitTests/SigningTests.swift
@@ -6,20 +6,58 @@ import XCTest
 final class SigningTests: XCTestCase {
     // MARK: SSHSIG detection
 
-    func testSSHSIGNamespaceParsed() {
+    /// Build a well-formed SSHSIG signed-data envelope (per PROTOCOL.sshsig).
+    private func sshsigBlob(namespace: String, reserved: Data = Data(),
+                            hashAlgorithm: String = "sha256", digestLen: Int = 32,
+                            trailing: Data = Data()) -> Data {
         var body = SSHWriter()
-        body.writeString("git") // the namespace, as an SSH string
-        let blob = SSHSIG.magic + body.data
-        XCTAssertEqual(SSHSIG.namespace(of: blob), "git")
+        body.writeString(namespace)
+        body.writeString(reserved)
+        body.writeString(hashAlgorithm)
+        body.writeString(Data(repeating: 0xAB, count: digestLen))
+        return SSHSIG.magic + body.data + trailing
     }
 
-    func testNonSSHSIGReturnsNil() {
+    func testValidSSHSIGClassified() {
+        let blob = sshsigBlob(namespace: "git")
+        XCTAssertEqual(SSHSIG.classify(blob), .valid(.init(namespace: "git", hashAlgorithm: "sha256")))
+        XCTAssertEqual(SSHSIG.classify(sshsigBlob(namespace: "file", hashAlgorithm: "sha512", digestLen: 64)),
+                       .valid(.init(namespace: "file", hashAlgorithm: "sha512")))
+    }
+
+    func testNonSSHSIGClassified() {
         // An ordinary SSH auth payload (session id + fields) never starts with the magic.
         var auth = SSHWriter()
         auth.writeString("session-id-bytes")
-        XCTAssertNil(SSHSIG.namespace(of: auth.data))
-        XCTAssertNil(SSHSIG.namespace(of: Data([0x00, 0x01, 0x02])))
-        XCTAssertNil(SSHSIG.namespace(of: Data("SSHSIG".utf8))) // magic but no namespace
+        XCTAssertEqual(SSHSIG.classify(auth.data), .notSSHSIG)
+        XCTAssertEqual(SSHSIG.classify(Data([0x00, 0x01, 0x02])), .notSSHSIG)
+    }
+
+    func testMalformedSSHSIGRejected() {
+        // Magic + namespace only (the pre-fix parser accepted this) — now malformed.
+        var nsOnly = SSHWriter(); nsOnly.writeString("git")
+        XCTAssertEqual(SSHSIG.classify(SSHSIG.magic + nsOnly.data), .malformed)
+        // Magic alone.
+        XCTAssertEqual(SSHSIG.classify(Data("SSHSIG".utf8)), .malformed)
+        // Trailing bytes after a complete envelope.
+        XCTAssertEqual(SSHSIG.classify(sshsigBlob(namespace: "git", trailing: Data([0xFF]))), .malformed)
+        // Empty namespace.
+        XCTAssertEqual(SSHSIG.classify(sshsigBlob(namespace: "")), .malformed)
+        // Unsupported hash algorithm.
+        XCTAssertEqual(SSHSIG.classify(sshsigBlob(namespace: "git", hashAlgorithm: "md5")), .malformed)
+        // Digest length that doesn't match the algorithm (sha256 wants 32).
+        XCTAssertEqual(SSHSIG.classify(sshsigBlob(namespace: "git", digestLen: 16)), .malformed)
+        // Invalid UTF-8 namespace.
+        var badNS = SSHWriter()
+        badNS.writeString(Data([0xFF, 0xFE]))
+        badNS.writeString(Data()); badNS.writeString("sha256"); badNS.writeString(Data(repeating: 0, count: 32))
+        XCTAssertEqual(SSHSIG.classify(SSHSIG.magic + badNS.data), .malformed)
+    }
+
+    func testSanitizeNamespaceStripsControlChars() {
+        XCTAssertEqual(Agent.sanitizeNamespace("git\nrm -rf"), "gitrm -rf")
+        XCTAssertEqual(Agent.sanitizeNamespace("git"), "git")
+        XCTAssertEqual(Agent.sanitizeNamespace(String(repeating: "x", count: 200)).count, 64)
     }
 
     // MARK: Namespace policy


### PR DESCRIPTION
Addresses all four findings from the external audit of v0.16.0 (`e3d87b0`). Each was verified against the code first; none breaks fob's cross-user/remote boundary — they are correctness + hardening fixes where the code was looser than its own comments and UI implied. One commit per finding.

## CG-02 — Fail closed on policy mutation; transactional rename (Medium)
The signing path failed closed on an unreadable policy, but every read-modify-write path (pin/unpin, reuse, namespaces, auto-harden, setup-pin, rotation) used a helper mapping `unreadable → open default` — so a transient/corrupt read + any later mutation silently rewrote the record **without its pins**. `rename` moved the key blob before migrating the policy under a swallowed `try?`.
- New `loadPolicyForMutation` throws on unreadable; `policy(name:)` → `displayPolicy(name:)` (display-only).
- All mutations route through it and surface the error instead of proceeding.
- `rename` loads the policy before moving anything and rolls the blob back on failure.

## CG-01 — Strict SSHSIG parsing (Medium)
`SSHSIG.namespace(of:)` checked only the magic + first string, then the agent signed the whole unvalidated blob under a "sign a git commit" label.
- New strict `classify()` → `notSSHSIG` / `malformed` / `valid` (validates namespace, reserved, `hash_algorithm ∈ {sha256,sha512}`, digest length, and EOF).
- Malformed SSHSIG is refused (not signed, not fallen through to SSH auth); namespace sanitized before prompts/notifications/audit.

## CG-03 — Config-derived values could become ssh options (Low)
`isValidHostToken` only blocked empty/space/leading-dash and wasn't applied to `User`/`HostName` parsed from `~/.ssh/config`.
- Hardened to reject a leading `-` and any control/whitespace char; applied before every ssh subprocess; `--` inserted before the destination.

## CG-04 — First-use `accept-new` could pin a MITM key (Low)
- Verify uses `StrictHostKeyChecking=yes` when the host is already known; only genuinely first-seen hosts use `accept-new`.
- The Migrate UI now labels a first-use connection as trust-on-first-use (not "verified") and shows the host key's `SHA256:…` fingerprint to confirm before pinning.

## Verification
`swift build` clean; **114 tests pass** (`swift test`), including new coverage: policy-mutation fail-closed + rename rollback (faulty PolicyStore), strict SSHSIG rejection cases, hardened token validation, and the fingerprint helper. The rewritten SSHSIG test now *rejects* the old namespace-only input.

_(The raw `ChatGPT-Security.md` is kept locally, untracked; happy to fold its resolution into `SECURITY_CLAUDE_REPORT.md` if you want it in-repo.)_