### PR TITLE
Make Configure pages scroll instead of clipping

### DIFF
--- a/Sources/FobApp/HostSetupView.swift
+++ b/Sources/FobApp/HostSetupView.swift
@@ -33,17 +33,19 @@ struct HostSetupView: View {
     @State private var bareResult: AppState.GeneratedKey?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 10) {
-                FobKeyGlyph(size: 28)
-                Text(headerTitle).font(.title2.weight(.semibold))
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 10) {
+                    FobKeyGlyph(size: 28)
+                    Text(headerTitle).font(.title2.weight(.semibold))
+                }
+                if let bareResult { bareResultView(bareResult) }
+                else if let result { resultView(result) }
+                else { formView }
             }
-            if let bareResult { bareResultView(bareResult) }
-            else if let result { resultView(result) }
-            else { formView }
+            .padding(22)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(22)
-        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear(perform: applyPrefill)
     }
 

--- a/Sources/FobApp/MigrateView.swift
+++ b/Sources/FobApp/MigrateView.swift
@@ -26,13 +26,18 @@ struct MigrateView: View {
             } else {
                 Text("SERVERS IN ~/.ssh/config").font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary).tracking(0.6)
-                VStack(spacing: 0) {
-                    ForEach(Array(servers.enumerated()), id: \.element.id) { index, s in
-                        serverRow(s)
-                        if index < servers.count - 1 { Divider() }
+                // Bound + scroll the list so a long ~/.ssh/config doesn't push the rest of
+                // the page (signing line, Refresh) past the bottom of the window.
+                ScrollView {
+                    VStack(spacing: 0) {
+                        ForEach(Array(servers.enumerated()), id: \.element.id) { index, s in
+                            serverRow(s)
+                            if index < servers.count - 1 { Divider() }
+                        }
                     }
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
                 }
-                .background(RoundedRectangle(cornerRadius: 8).fill(Color.secondary.opacity(0.08)))
+                .frame(maxHeight: 360)
             }
 
             if let signing { signingLine(signing) }

--- a/Sources/FobApp/RotateKeyView.swift
+++ b/Sources/FobApp/RotateKeyView.swift
@@ -34,27 +34,29 @@ struct RotateKeyView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 10) {
-                FobKeyGlyph(size: 28)
-                Text("Rotate — \(name)").font(.title2.weight(.semibold))
-            }
-            if done { doneView }
-            else if prep == nil { startView }
-            else {
-                switch role {
-                case .signing: signingFlow
-                case .server: serverFlow
-                case .git: gitFlow
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 10) {
+                    FobKeyGlyph(size: 28)
+                    Text("Rotate — \(name)").font(.title2.weight(.semibold))
+                }
+                if done { doneView }
+                else if prep == nil { startView }
+                else {
+                    switch role {
+                    case .signing: signingFlow
+                    case .server: serverFlow
+                    case .git: gitFlow
+                    }
+                }
+                if let error {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
                 }
             }
-            if let error {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption).foregroundStyle(.red).fixedSize(horizontal: false, vertical: true)
-            }
+            .padding(22)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(22)
-        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { candidate = state.migrationCandidate(alias: name) }
         .onDisappear { if prep != nil && !done { state.cancelRotation(name: name) } } // drop an abandoned temp key
     }

--- a/Sources/FobApp/SigningSetupView.swift
+++ b/Sources/FobApp/SigningSetupView.swift
@@ -23,15 +23,17 @@ struct SigningSetupView: View {
     private var keyName: String { state.signingSetupKey ?? "" }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 10) {
-                FobKeyGlyph(size: 28)
-                Text("Commit signing — \(keyName)").font(.title2.weight(.semibold))
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 10) {
+                    FobKeyGlyph(size: 28)
+                    Text("Commit signing — \(keyName)").font(.title2.weight(.semibold))
+                }
+                if let info { content(info) } else { Text("Key unavailable.").foregroundStyle(.secondary) }
             }
-            if let info { content(info) } else { Text("Key unavailable.").foregroundStyle(.secondary) }
+            .padding(22)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .padding(22)
-        .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear { load() }
         .onChange(of: state.signingSetupKey) { _ in load() }
     }


### PR DESCRIPTION
The Configure window tabs are fixed-height with no scroll, so content taller than the window is clipped with no way to reach the bottom — most visibly the **Migrate** tab's server list on a machine with many `~/.ssh/config` hosts (reported).

- **Migrate**: the server list is now a bounded `ScrollView` (maxHeight 360), matching the **Keys** tab, so it scrolls and the signing line + Refresh stay reachable.
- **New key**, **Commit signing**, **Rotate**: page body wrapped in a `ScrollView` so a tall form/result scrolls instead of clipping.

Settings is short (left as-is); Keys/Checkup/Audit already scroll. Pure UI; 106 tests pass.