### PR TITLE
Export fob public keys as 0600, not 0644

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -317,7 +317,7 @@ final class AppState: ObservableObject {
             let pubURL = sshDir.appendingPathComponent("fob_\(alias).pub")
             let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(alias)")
             try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
 
             let configURL = sshDir.appendingPathComponent("config")
             let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
@@ -515,7 +515,7 @@ final class AppState: ObservableObject {
                                                     withIntermediateDirectories: true,
                                                     attributes: [.posixPermissions: 0o700])
             try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
             refreshKeys()
         } catch {
             return .failed(error.localizedDescription)
@@ -603,7 +603,7 @@ final class AppState: ObservableObject {
                                                     withIntermediateDirectories: true,
                                                     attributes: [.posixPermissions: 0o700])
             try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
 
             let existing = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
             if !HostSetup.hostBlockExists(alias: alias, in: existing) {
@@ -636,7 +636,7 @@ final class AppState: ObservableObject {
                                                     withIntermediateDirectories: true,
                                                     attributes: [.posixPermissions: 0o700])
             try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
             refreshKeys()
             return .ok(pubLine: pubLine)
         } catch {
@@ -946,7 +946,7 @@ final class AppState: ObservableObject {
             return nil
         }
         try? Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
         let signer = (try? store.ensureSignWrapper()) ?? store.signWrapperPath
         return SigningInfo(
             name: name, pubLine: pubLine, pubPath: pubURL.path,

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -66,7 +66,7 @@ enum Setup {
         }
         let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(alias)")
         try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
         print("Public key exported to \(pubURL.path).")
 
         let newConfig = HostSetup.migratedConfig(configText, alias: alias,
@@ -257,7 +257,7 @@ enum Setup {
         let pubURL = sshDir.appendingPathComponent("fob_\(alias).pub")
         let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(alias)")
         try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
         print("Public key exported to \(pubURL.path).")
 
         let destination = "\(user)@\(host)"

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -421,7 +421,7 @@ do {
         let pubURL = sshDir.appendingPathComponent("fob_\(name).pub")
         let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
         try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
         let signer = try store.ensureSignWrapper()
         print("Enable Touch ID-gated git commit signing with fob key '\(name)'.")
         print("Public key exported to \(pubURL.path).")
@@ -524,7 +524,7 @@ do {
             let pubLine = SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(name)")
             let pubURL = sshDir.appendingPathComponent("fob_\(name).pub")
             try Data((pubLine + "\n").utf8).write(to: pubURL, options: .atomic)
-            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: pubURL.path)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: pubURL.path)
             try? FileManager.default.removeItem(at: sshDir.appendingPathComponent("fob_\(temp).pub"))
             if let email = signingEmail, !email.isEmpty {
                 var text = signersText


### PR DESCRIPTION
Fixes a confusing failure a user hit: `ssh <host>` printing **"UNPROTECTED PRIVATE KEY FILE! Permissions 0644 for …/fob_<name>.pub are too open … This private key will be ignored"** and dropping to a password prompt.

## Cause
fob points ssh at `~/.ssh/fob_<name>.pub` via `IdentityFile`. When the agent is momentarily unavailable (right after login before fob.app starts, or during a restart), ssh falls back to loading that `IdentityFile` **as a private key** — and OpenSSH refuses any world/group-readable (0644) file in that role with the message above. The `.pub` is fine and identical to working hosts; the perms are the trap.

## Fix
Export every `fob_<name>.pub` as **0600**. That makes the fallback a clean skip instead of a scary error. It doesn't change the normal agent path (owner-read either way), and the server's `authorized_keys` copy is unaffected. `allowed_signers` stays 0644 (a plain config file, not an IdentityFile).

Applies to all export sites (new key, setup, migrate, rotate) in app + CLI. Existing pubs: `chmod 600 ~/.ssh/fob_*.pub` (already done on the reporter's machine). 106 tests pass.