### PR TITLE
Settings: explain fob's agent vs the system ssh-agent

### DIFF
--- a/Sources/FobApp/SettingsView.swift
+++ b/Sources/FobApp/SettingsView.swift
@@ -6,6 +6,11 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var state: AppState
     @State private var checking = false
+    @State private var copiedList = false
+
+    /// The command to list fob's keys via ssh-add (fob keys live in fob's own agent, so a
+    /// plain `ssh-add -l` — which talks to the system agent — won't show them).
+    private var listKeysCommand: String { "SSH_AUTH_SOCK=\(state.socketPath) ssh-add -l" }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -62,6 +67,22 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                 Text("Point ssh at this in `~/.ssh/config` with `IdentityAgent`.")
                     .font(.caption).foregroundStyle(.tertiary)
+
+                Text("Your keys live in fob's **own** agent — a plain `ssh-add -l` talks to the system agent and won't list them (that's expected, not a lost key). List fob's keys with:")
+                    .font(.caption).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
+                HStack(spacing: 8) {
+                    Text(listKeysCommand)
+                        .font(.system(.caption2, design: .monospaced)).textSelection(.enabled)
+                        .padding(6)
+                        .background(RoundedRectangle(cornerRadius: 5).fill(Color.secondary.opacity(0.12)))
+                    Button(copiedList ? "Copied" : "Copy") {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(listKeysCommand, forType: .string)
+                        copiedList = true
+                    }.font(.caption)
+                }
             }
 
             Spacer(minLength: 0)


### PR DESCRIPTION
Removes a genuine footgun hit after a reboot: `ssh-add -l` prints **"The agent has no identities"** and it looks like your fob keys vanished — but fob keys live in fob's **own** agent (`~/.fob/agent.sock`, reached via `IdentityAgent`), not the system ssh-agent, so a plain `ssh-add -l` is *expected* to look empty. `ssh <host>` still works via `IdentityAgent`.

The Settings → **Agent socket** section now:
- states this in one line ("that's expected, not a lost key"), and
- offers a copy-able **`SSH_AUTH_SOCK=<socket> ssh-add -l`** to actually list fob's keys.

Small, self-contained UI copy; 114 tests pass; build clean.