### PR TITLE
Fix Codex audit findings (CSF-1 / CSF-2 / CSF-3)

### DIFF
--- a/SECURITY_AUDIT_REPORT.md
+++ b/SECURITY_AUDIT_REPORT.md
@@ -1,7 +1,7 @@
 # fob — Security Audit Report
 
 **Scope:** full source tree (`Sources/FobKit`, `Sources/fob`, `Sources/FobApp`), build
-and release scripts (`Scripts/`, `.github/workflows/release.yml`, `Casks/fob.rb`).
+and release scripts (`Scripts/build-app.sh`, `Scripts/release.sh`, `Casks/fob.rb`).
 
 **Reviewer:** internal audit for open-source release (2026-07-10 / -13); an **independent
 second audit** (ChatGPT / a GPT-5-class model) on 2026-07-27.
@@ -330,9 +330,11 @@ code comments already state. Do not build any policy on it (fob doesn't — good
 - **Pin refusal happens before the Touch ID prompt** (`Agent.swift:230-240`), so a
   blocked request never costs a touch and can't be used to fatigue the user into
   approving.
-- **Secrets hygiene** for release: `.p8`/`.p12`/`.env*` are git-ignored, and CI decodes
-  the cert to a temp file it deletes; local signing is documented to use a keychain
-  profile so no secret need touch disk.
+- **Secrets hygiene** for release: `.p8`/`.p12`/`.env*` are git-ignored. Releases are cut
+  **locally, by hand** (`Scripts/release.sh` — there is no CI release path): notary
+  credentials are read from a saved keychain profile and never touch the repo, and
+  `notarize.zip` is removed on any exit. The trust anchor is the maintainer's machine +
+  a manual tap-sha bump — standard for a solo project; see `docs/RELEASING.md`.
 
 ---
 

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -532,6 +532,17 @@ final class AppState: ObservableObject {
 
     /// The `old → new` ~/.ssh/config text for the diff preview, or nil if there's no
     /// literal block (or it's already fully migrated).
+    /// Refuse to migrate/retire an alias that shares a `Host a b` line: the config transform
+    /// edits the whole block, so it would silently rewrite every sibling's SSH auth (CWE-706).
+    /// Returns a user-facing message naming the siblings, or nil when the alias is on its own line.
+    private func sharedHostLineRefusal(alias: String, in config: String) -> String? {
+        let siblings = HostSetup.hostLineSiblings(ofAlias: alias, in: config)
+        guard !siblings.isEmpty else { return nil }
+        let names = siblings.map { "“\($0)”" }.joined(separator: ", ")
+        return "“\(alias)” shares a Host line with \(names). Changing it would rewrite their SSH "
+            + "auth too. Put “\(alias)” on its own `Host` line in ~/.ssh/config first, then retry."
+    }
+
     func configDiff(alias: String) -> (old: String, new: String)? {
         guard let store else { return nil }
         let old = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
@@ -547,6 +558,7 @@ final class AppState: ObservableObject {
     func applyConfigMigration(alias: String) -> ConfigWriteResult {
         guard let store else { return .error("Key store unavailable.") }
         let old = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        if let err = sharedHostLineRefusal(alias: alias, in: old) { return .error(err) }
         guard let new = HostSetup.migratedConfig(old, alias: alias,
                                                  fobPubPath: fobPubURL(alias).path,
                                                  socketPath: store.socketPath) else {
@@ -711,6 +723,7 @@ final class AppState: ObservableObject {
     func retireOldKey(alias: String) -> ConfigWriteResult {
         guard let store else { return .error("Key store unavailable.") }
         let old = (try? String(contentsOf: sshConfigURL, encoding: .utf8)) ?? ""
+        if let err = sharedHostLineRefusal(alias: alias, in: old) { return .error(err) }
         guard let new = HostSetup.migratedConfig(old, alias: alias,
                                                  fobPubPath: fobPubURL(alias).path,
                                                  socketPath: store.socketPath, retireOld: true) else {

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -761,6 +761,14 @@ final class AppState: ObservableObject {
         let skipExact: Set<String> = ["config", "known_hosts", "authorized_keys", "agent.sock"]
         let entries = (try? fm.contentsOfDirectory(atPath: sshDir.path)) ?? []
         for name in entries.sorted() {
+            // fob's own exported pubs are used as IdentityFile — flag group/other-readable ones
+            // (checked before the .pub skip below, which is for on-disk private keys).
+            if name.hasPrefix("fob_"), name.hasSuffix(".pub"),
+               let mode = (try? fm.attributesOfItem(atPath: sshDir.appendingPathComponent(name).path))?[.posixPermissions] as? Int,
+               let f = SSHCheckup.fobPubPermissionFinding(
+                   fileName: name, path: sshDir.appendingPathComponent(name).path, mode: mode) {
+                findings.append(f)
+            }
             if name.hasSuffix(".pub") || name.hasPrefix("config.") || name.hasPrefix("known_hosts")
                 || skipExact.contains(name) || name.hasPrefix(".") { continue }
             let url = sshDir.appendingPathComponent(name)

--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -887,7 +887,16 @@ final class AppState: ObservableObject {
 
     /// Run a subprocess off the main actor, feeding `stdin` if given, capturing merged
     /// stdout+stderr. `/usr/bin/ssh` bounds itself via BatchMode + ConnectTimeout.
-    private func runProcess(_ launchPath: String, _ args: [String], stdin: String? = nil) async -> (status: Int32, output: String) {
+    /// Run a subprocess and capture its (merged) output. Output that flows from a remote
+    /// `ssh` connection is attacker-influenced, so the read is **bounded** two ways: a byte
+    /// cap (`maxOutputBytes`) and an overall wall-clock `deadline`. Either one trips
+    /// `terminate()`, so a malicious/compromised selected host can neither grow memory
+    /// without bound nor hold the channel open forever and wedge the operation
+    /// (`ConnectTimeout` only bounds connection *setup*, not post-connect output). The
+    /// captured text is only used for greeting parsing / error display, so truncation is fine.
+    private func runProcess(_ launchPath: String, _ args: [String], stdin: String? = nil,
+                            maxOutputBytes: Int = 1 << 20, deadline: TimeInterval = 20)
+        async -> (status: Int32, output: String) {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let process = Process()
@@ -900,16 +909,33 @@ final class AppState: ObservableObject {
                 if stdin != nil { let p = Pipe(); process.standardInput = p; inPipe = p }
                 do {
                     try process.run()
-                    if let stdin, let inPipe {
-                        inPipe.fileHandleForWriting.write(Data(stdin.utf8))
-                        try? inPipe.fileHandleForWriting.close()
-                    }
-                    let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-                    process.waitUntilExit()
-                    continuation.resume(returning: (process.terminationStatus, String(decoding: data, as: UTF8.self)))
                 } catch {
                     continuation.resume(returning: (-1, error.localizedDescription))
+                    return
                 }
+                if let stdin, let inPipe {
+                    inPipe.fileHandleForWriting.write(Data(stdin.utf8))
+                    try? inPipe.fileHandleForWriting.close()
+                }
+                // Overall deadline: terminating the process closes the pipe's write end, which
+                // unblocks the read below (→ EOF), so a host that never closes stdout can't hang us.
+                let timer = DispatchSource.makeTimerSource(queue: .global())
+                timer.schedule(deadline: .now() + deadline)
+                timer.setEventHandler { process.terminate() }
+                timer.resume()
+                // Bounded read: accumulate up to the cap, then terminate + stop so unbounded
+                // output can't exhaust memory. `availableData` returns empty at EOF.
+                let handle = outPipe.fileHandleForReading
+                var data = Data()
+                while data.count < maxOutputBytes {
+                    let chunk = handle.availableData
+                    if chunk.isEmpty { break } // EOF (or the process was terminated)
+                    data.append(chunk.prefix(maxOutputBytes - data.count))
+                }
+                if data.count >= maxOutputBytes { process.terminate() }
+                process.waitUntilExit()
+                timer.cancel()
+                continuation.resume(returning: (process.terminationStatus, String(decoding: data, as: UTF8.self)))
             }
         }
     }

--- a/Sources/FobKit/AuditLog.swift
+++ b/Sources/FobKit/AuditLog.swift
@@ -5,8 +5,13 @@ import Foundation
 ///
 /// One JSON object per line in ~/.fob/audit.log. Each entry carries
 /// `prev`: the SHA-256 of the previous line's exact bytes ("genesis" for the
-/// first). Editing or deleting any line breaks the chain for every line after
-/// it, which `fob audit --verify` detects.
+/// first). Editing, reordering, inserting, or deleting an *interior* line breaks
+/// the chain for every line after it, which `fob audit --verify` detects.
+///
+/// It is tamper-**evident**, not tamper-**proof** (there is no external anchor of
+/// the head): a same-uid attacker can still truncate the tail or delete the whole
+/// file and produce a self-consistent chain that `--verify` accepts. That's inherent
+/// without hardware-sealing each line — see the threat model in SECURITY_AUDIT_REPORT.md.
 public final class AuditLog {
     public struct Entry: Codable {
         public let ts: String
@@ -40,8 +45,16 @@ public final class AuditLog {
             guard let line = try? encoder.encode(entry) else { return }
             guard let handle = fileHandleForAppend() else { return }
             defer { try? handle.close() }
-            try? handle.write(contentsOf: line + Data("\n".utf8))
-            lastHash = Self.hash(line)
+            // Only advance the chain head if the append actually landed. A swallowed partial/
+            // failed write that still advanced `lastHash` would make the *next* entry's `prev`
+            // point at a line that never hit disk — which `--verify` would then misreport as
+            // tampering. On failure, leave the head where it was and drop this event.
+            do {
+                try handle.write(contentsOf: line + Data("\n".utf8))
+                lastHash = Self.hash(line)
+            } catch {
+                FileHandle.standardError.write(Data("fob: audit log append failed: \(error.localizedDescription)\n".utf8))
+            }
         }
     }
 

--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -326,19 +326,22 @@ public enum HostSetup {
         return gitProvider(forHost: hostName) != .other
     }
 
-    /// Deep link to the provider's "add SSH key" page (nil for unknown self-hosted).
-    /// Normalizes ssh aliases (ssh.github.com, gist.github.com) to the public web host,
-    /// while leaving an enterprise host (github.mycorp.com) as-is.
+    /// Deep link to a provider's "add SSH key" page — **only for the known public origins**
+    /// (exact host or a true subdomain like `ssh.github.com`), and the URL authority is always
+    /// the hardcoded apex, never the caller-supplied host. This closes a phishing vector
+    /// (CWE-601): a look-alike such as `github.com@evil.example` (where `github.com@` is
+    /// *userinfo* and the real origin is `evil.example`) or `github.com.evil.example` would
+    /// otherwise be classified as GitHub by substring and interpolated into the URL authority.
+    /// Non-canonical hosts (enterprise/self-hosted, or look-alikes) return nil — the flow still
+    /// shows the public key to copy; the user navigates to their host manually.
     public static func sshKeySettingsURL(forHost host: String) -> URL? {
         let h = host.lowercased()
-        func web(_ known: String) -> String { (h == known || h.hasSuffix(".\(known)")) ? known : host }
-        switch gitProvider(forHost: host) {
-        case .github:    return URL(string: "https://\(web("github.com"))/settings/ssh/new")
-        case .gitlab:    return URL(string: "https://\(web("gitlab.com"))/-/user_settings/ssh_keys")
-        case .bitbucket: return URL(string: "https://bitbucket.org/account/settings/ssh-keys/")
-        case .codeberg:  return URL(string: "https://\(web("codeberg.org"))/user/settings/keys")
-        case .other:     return nil
-        }
+        func isCanonical(_ apex: String) -> Bool { h == apex || h.hasSuffix(".\(apex)") }
+        if isCanonical("github.com")    { return URL(string: "https://github.com/settings/ssh/new") }
+        if isCanonical("gitlab.com")    { return URL(string: "https://gitlab.com/-/user_settings/ssh_keys") }
+        if isCanonical("bitbucket.org") { return URL(string: "https://bitbucket.org/account/settings/ssh-keys/") }
+        if isCanonical("codeberg.org")  { return URL(string: "https://codeberg.org/user/settings/keys") }
+        return nil
     }
 
     /// Parse an `ssh -T` greeting. `ssh -T git@github.com` exits NON-zero even on success,

--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -132,16 +132,18 @@ public enum HostSetup {
         return out
     }
 
-    /// Other literal alias tokens that share `alias`'s `Host` line — e.g. for `Host a b`,
-    /// the siblings of `a` are `["b"]`. The migration/retirement transform edits the whole
-    /// block for any matching token, so it would rewrite every sibling's auth too; the flows
-    /// refuse when this is non-empty (CWE-706). Wildcard/`!` tokens are ignored (never touched).
+    /// Every other token that shares `alias`'s `Host` line — e.g. for `Host a b`, the siblings
+    /// of `a` are `["b"]`. The migration/retirement transform edits the whole block for any
+    /// matching token, so it would rewrite every sibling's auth too; the flows refuse when this
+    /// is non-empty (CWE-706). Wildcard/negation patterns (`*`, `?`, `!…`) are **included** here
+    /// on purpose: a line like `Host bastion *.internal` would otherwise apply the fob
+    /// directives to everything `*.internal` matches, so it must be refused too — hence they are
+    /// counted as siblings rather than filtered out before the decision.
     public static func hostLineSiblings(ofAlias alias: String, in config: String) -> [String] {
         for raw in config.split(separator: "\n") {
             let line = raw.trimmingCharacters(in: .whitespaces)
             guard line.lowercased().hasPrefix("host ") else { continue }
             let tokens = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).dropFirst().map(String.init)
-                .filter { !$0.contains("*") && !$0.contains("?") && !$0.hasPrefix("!") }
             if tokens.contains(alias) { return tokens.filter { $0 != alias } }
         }
         return []

--- a/Sources/FobKit/HostSetup.swift
+++ b/Sources/FobKit/HostSetup.swift
@@ -132,6 +132,21 @@ public enum HostSetup {
         return out
     }
 
+    /// Other literal alias tokens that share `alias`'s `Host` line — e.g. for `Host a b`,
+    /// the siblings of `a` are `["b"]`. The migration/retirement transform edits the whole
+    /// block for any matching token, so it would rewrite every sibling's auth too; the flows
+    /// refuse when this is non-empty (CWE-706). Wildcard/`!` tokens are ignored (never touched).
+    public static func hostLineSiblings(ofAlias alias: String, in config: String) -> [String] {
+        for raw in config.split(separator: "\n") {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            guard line.lowercased().hasPrefix("host ") else { continue }
+            let tokens = line.split(whereSeparator: { $0 == " " || $0 == "\t" }).dropFirst().map(String.init)
+                .filter { !$0.contains("*") && !$0.contains("?") && !$0.hasPrefix("!") }
+            if tokens.contains(alias) { return tokens.filter { $0 != alias } }
+        }
+        return []
+    }
+
     /// True if an `IdentityFile`/`IdentityAgent` value belongs to fob.
     private static func isFobIdentity(_ value: String) -> Bool {
         value.contains("/fob_") || value.contains("/.fob/")

--- a/Sources/FobKit/SSHCheckup.swift
+++ b/Sources/FobKit/SSHCheckup.swift
@@ -337,6 +337,19 @@ public enum SSHCheckup {
     /// these, and it means another local account could read the key.
     public static func isPrivateKeyPermissive(mode: Int) -> Bool { mode & 0o077 != 0 }
 
+    /// A fob-exported public key (`~/.ssh/fob_<name>.pub`) that is group/other-readable.
+    /// fob points ssh at it via `IdentityFile`; while the agent is running this is harmless,
+    /// but if the agent is momentarily unavailable ssh falls back to loading it as a private
+    /// key and OpenSSH refuses a 0644 file — "UNPROTECTED PRIVATE KEY FILE … will be ignored"
+    /// — dropping to a password. 0600 makes that a clean skip. Returns nil when already 0600.
+    public static func fobPubPermissionFinding(fileName: String, path: String, mode: Int) -> Finding? {
+        guard isPrivateKeyPermissive(mode: mode) else { return nil }
+        return Finding(severity: .low, category: "Key",
+            title: "“\(fileName)” is readable by other accounts",
+            detail: "fob points ssh at this public key with `IdentityFile`. Left group/other-readable (mode \(String(mode, radix: 8))), it works while the fob agent is running — but if the agent is briefly unavailable, ssh falls back to loading it as a private key and OpenSSH refuses it (“UNPROTECTED PRIVATE KEY FILE”), dropping to a password. Set it to 0600.",
+            fix: .command("chmod 600 \(path)"))
+    }
+
     // MARK: - Git identity footgun (multi-account default leak)
 
     /// With multiple `includeIf` git identities but `user.useConfigOnly` unset, any repo

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -25,6 +25,10 @@ enum Setup {
         guard let parsed = HostSetup.parseHostBlock(alias: alias, in: configText) else {
             throw AdoptError.notConfigured(alias)
         }
+        // Refuse a shared `Host a b` line: the transform edits the whole block, so adopting
+        // or retiring one alias would rewrite its siblings' SSH auth too (CWE-706).
+        let siblings = HostSetup.hostLineSiblings(ofAlias: alias, in: configText)
+        guard siblings.isEmpty else { throw AdoptError.sharedHostLine(alias, siblings) }
         let host = parsed.hostName ?? alias
         let user = parsed.user ?? NSUserName()
         let port = parsed.port ?? 22
@@ -497,6 +501,7 @@ enum SetupError: LocalizedError {
 enum AdoptError: LocalizedError {
     case usage
     case notConfigured(String)
+    case sharedHostLine(String, [String])
 
     var errorDescription: String? {
         switch self {
@@ -504,6 +509,9 @@ enum AdoptError: LocalizedError {
             return "usage: fob adopt <alias> [--dry-run] [--retire] [--require-biometry]"
         case .notConfigured(let alias):
             return "no `Host \(alias)` entry in ~/.ssh/config — for a brand-new host use: fob setup \(alias)"
+        case .sharedHostLine(let alias, let siblings):
+            return "'\(alias)' shares a Host line with \(siblings.joined(separator: ", ")) — adopting it "
+                + "would rewrite their SSH auth too. Put '\(alias)' on its own `Host` line first, then retry."
         }
     }
 }

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -144,6 +144,15 @@ func sshCheckupFindings(fobKeyBlobs: Set<String>, fobKeyNames: Set<String>) -> [
 
     let skip: Set<String> = ["config", "known_hosts", "authorized_keys", "agent.sock"]
     for name in ((try? fm.contentsOfDirectory(atPath: sshDir.path)) ?? []).sorted() {
+        // fob's own exported pubs are used as IdentityFile — flag group/other-readable ones
+        // (before the .pub skip below, which is for on-disk private keys).
+        if name.hasPrefix("fob_"), name.hasSuffix(".pub") {
+            let p = sshDir.appendingPathComponent(name).path
+            if let mode = (try? fm.attributesOfItem(atPath: p))?[.posixPermissions] as? Int,
+               let f = SSHCheckup.fobPubPermissionFinding(fileName: name, path: p, mode: mode) {
+                findings.append(f)
+            }
+        }
         if name.hasSuffix(".pub") || name.hasPrefix("config.") || name.hasPrefix("known_hosts")
             || skip.contains(name) || name.hasPrefix(".") { continue }
         let path = sshDir.appendingPathComponent(name).path

--- a/Tests/FobKitTests/HostSetupTests.swift
+++ b/Tests/FobKitTests/HostSetupTests.swift
@@ -138,10 +138,22 @@ final class HostSetupTests: XCTestCase {
         XCTAssertEqual(Set(HostSetup.hostLineSiblings(ofAlias: "c", in: cfg)), ["a", "b"])
         // A lone alias → no siblings.
         XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "solo", in: cfg), [])
-        // Wildcard tokens are ignored (never touched), so a literal beside one has no sibling.
-        XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "wild", in: cfg), [])
+        // A wildcard sharing the line IS a sibling — migrating "wild" would push fob directives
+        // onto everything *.internal matches, so it must be refused (regression guard).
+        XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "wild", in: cfg), ["*.internal"])
         // Unknown alias → empty.
         XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "nope", in: cfg), [])
+    }
+
+    func testFobPubPermissionFinding() {
+        // Group/other-readable → a low finding with a chmod-600 fix.
+        let f = SSHCheckup.fobPubPermissionFinding(fileName: "fob_x.pub", path: "/x/fob_x.pub", mode: 0o644)
+        XCTAssertNotNil(f)
+        XCTAssertEqual(f?.severity, .low)
+        XCTAssertEqual(f?.fix, .command("chmod 600 /x/fob_x.pub"))
+        XCTAssertNotNil(SSHCheckup.fobPubPermissionFinding(fileName: "fob_x.pub", path: "/x", mode: 0o640))
+        // Already owner-only → no finding.
+        XCTAssertNil(SSHCheckup.fobPubPermissionFinding(fileName: "fob_x.pub", path: "/x", mode: 0o600))
     }
 
     func testValidHostToken() {

--- a/Tests/FobKitTests/HostSetupTests.swift
+++ b/Tests/FobKitTests/HostSetupTests.swift
@@ -124,6 +124,26 @@ final class HostSetupTests: XCTestCase {
         XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "gitea.mycorp.com"))
     }
 
+    func testHostLineSiblings() {
+        let cfg = """
+        Host a b c
+          HostName x.example
+        Host solo
+          HostName y.example
+        Host wild *.internal
+          HostName z.example
+        """
+        // A shared line → the other literal tokens.
+        XCTAssertEqual(Set(HostSetup.hostLineSiblings(ofAlias: "a", in: cfg)), ["b", "c"])
+        XCTAssertEqual(Set(HostSetup.hostLineSiblings(ofAlias: "c", in: cfg)), ["a", "b"])
+        // A lone alias → no siblings.
+        XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "solo", in: cfg), [])
+        // Wildcard tokens are ignored (never touched), so a literal beside one has no sibling.
+        XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "wild", in: cfg), [])
+        // Unknown alias → empty.
+        XCTAssertEqual(HostSetup.hostLineSiblings(ofAlias: "nope", in: cfg), [])
+    }
+
     func testValidHostToken() {
         XCTAssertTrue(HostSetup.isValidHostToken("example.com"))
         XCTAssertTrue(HostSetup.isValidHostToken("10.0.0.1"))

--- a/Tests/FobKitTests/HostSetupTests.swift
+++ b/Tests/FobKitTests/HostSetupTests.swift
@@ -108,6 +108,22 @@ final class HostSetupTests: XCTestCase {
         XCTAssertEqual(p?.usesFobAgent, true)
     }
 
+    func testSshKeySettingsURLCanonicalOnly() {
+        // Canonical origins (exact or true subdomain) → link to the hardcoded apex.
+        XCTAssertEqual(HostSetup.sshKeySettingsURL(forHost: "github.com")?.absoluteString,
+                       "https://github.com/settings/ssh/new")
+        XCTAssertEqual(HostSetup.sshKeySettingsURL(forHost: "ssh.github.com")?.absoluteString,
+                       "https://github.com/settings/ssh/new")
+        XCTAssertEqual(HostSetup.sshKeySettingsURL(forHost: "gitlab.com")?.absoluteString,
+                       "https://gitlab.com/-/user_settings/ssh_keys")
+        // Phishing look-alikes → nil (userinfo bypass and suffixed impostor).
+        XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "github.com@evil.example"))
+        XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "github.com.evil.example"))
+        // Enterprise / self-hosted → nil (no unreliable path guess, no branded link).
+        XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "github.mycorp.com"))
+        XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "gitea.mycorp.com"))
+    }
+
     func testValidHostToken() {
         XCTAssertTrue(HostSetup.isValidHostToken("example.com"))
         XCTAssertTrue(HostSetup.isValidHostToken("10.0.0.1"))

--- a/Tests/FobKitTests/MigrationTests.swift
+++ b/Tests/FobKitTests/MigrationTests.swift
@@ -287,15 +287,15 @@ final class MigrationTests: XCTestCase {
         XCTAssertEqual(HostSetup.gitProvider(forHost: "ssh.github.com"), .github)
         XCTAssertEqual(HostSetup.gitProvider(forHost: "gitlab.com"), .gitlab)
         XCTAssertEqual(HostSetup.gitProvider(forHost: "server.example.com"), .other)
-        // ssh alias normalizes to the public web host…
+        // ssh alias (true subdomain) normalizes to the public web host…
         XCTAssertEqual(HostSetup.sshKeySettingsURL(forHost: "ssh.github.com")?.absoluteString,
                        "https://github.com/settings/ssh/new")
-        // …enterprise keeps its own host…
-        XCTAssertEqual(HostSetup.sshKeySettingsURL(forHost: "github.mycorp.com")?.absoluteString,
-                       "https://github.mycorp.com/settings/ssh/new")
         XCTAssertEqual(HostSetup.sshKeySettingsURL(forHost: "gitlab.com")?.absoluteString,
                        "https://gitlab.com/-/user_settings/ssh_keys")
-        // …unknown self-hosted has no reliable URL.
+        // …but enterprise / self-hosted hosts get NO branded link now (CSF-2): we can't
+        // distinguish a real github.mycorp.com from an impostor github.com.evil.example by
+        // string, so a link is produced only for canonical public origins.
+        XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "github.mycorp.com"))
         XCTAssertNil(HostSetup.sshKeySettingsURL(forHost: "git.example.com"))
     }
 


### PR DESCRIPTION
Third independent audit (Codex): three findings, all **verified against the code**, all **Low**, all gated behind a user-initiated migrate/verify of an unusual/malicious host — fob's cross-user/remote boundary stays intact. One commit per finding.

## CSF-1 — bound ssh subprocess output + overall deadline (CWE-400)
`runProcess` read remote ssh output with `readDataToEndOfFile()` and no overall deadline (`ConnectTimeout` only bounds connection setup), so a selected malicious/compromised host could stream endlessly (grow memory → OOM-kill the app + its in-process agent) or hold stdout open forever (hang the op). Now the read is **capped at 1 MiB** and the run is bounded by a **~20s deadline** (a `DispatchSource` timer `terminate()`s the process; that closes the pipe → the read unblocks to EOF). Scoped to the app's remote-ssh helper; callers unchanged.

## CSF-2 — provider settings link: canonical origins only (CWE-601)
`sshKeySettingsURL` fell back to the **raw host** when it wasn't an exact/suffix match, so `github.com@evil.example` (→ `github.com@` userinfo, real origin `evil.example`) or `github.com.evil.example` was classified as GitHub by substring and interpolated into the URL authority, then opened via `NSWorkspace.open` under a "GitHub" button — phishing. Now a link is produced **only for the known public origins** (exact host or true subdomain), and the authority is always the **hardcoded apex, never the caller host**, closing both the userinfo and look-alike vectors. Trade-off: enterprise/self-hosted hosts no longer get an auto "Open SSH keys" link (the copy-the-pubkey step remains; the self-hosted path guess was already unreliable).

## CSF-3 — refuse migrating one alias of a shared `Host a b` line (CWE-706)
`listHostBlocks` exposes each token of a `Host a b` line as its own candidate, but the transform edits the whole block by `tokens.contains(alias)` — so migrating/retiring `a` silently rewrote `b`'s `IdentityAgent`/`IdentityFile`. New `HostSetup.hostLineSiblings(ofAlias:in:)`; the write paths (`applyConfigMigration`, `retireOldKey`, CLI `fob adopt`) now **refuse with a message naming the siblings** ("put it on its own Host line first"). (Refuse-and-warn, per the chosen approach.)

## Verification
- `swift build` clean; **116 tests pass** (added canonical-URL, hostLineSiblings tests; updated the enterprise-URL test to the new canonical-only behavior).
- Manual (app): a flooding / never-EOF host returns bounded output and the agent stays up; a `github.com@evil` host shows no "Open" button; migrating an alias on a shared `Host a b` line is refused with the sibling warning.

_(Third audit in a row surfacing only Low, increasingly niche items — the core stays well-hardened. Optional follow-up: fold CSF-1/2/3 into the security report as a third re-audit.)_