### PR TITLE
Update banner: one-click Update via Homebrew

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -718,6 +718,20 @@ final class AppState: ObservableObject {
         NSWorkspace.shared.open(url)
     }
 
+    /// One-click update: open Terminal and run the Homebrew upgrade, then reopen fob. fob is
+    /// distributed as a cask, so brew stays the source of truth — this just saves the user the
+    /// copy-paste. The command is a constant (no injection surface); Terminal owns the process,
+    /// so it survives the cask quitting/replacing fob mid-upgrade, and `&& open -a fob` relaunches
+    /// only on success. A non-Homebrew (source) install simply sees brew's "not installed" error.
+    func updateViaHomebrew() {
+        let command = "brew upgrade --cask fob && open -a fob"
+        let script = "tell application \"Terminal\"\nactivate\ndo script \"\(command)\"\nend tell"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+        try? process.run()
+    }
+
     /// Comment out the old `IdentityFile` in the block (the explicit, optional retire step),
     /// after the user has confirmed fob works. Returns the backup filename or an error.
     func retireOldKey(alias: String) -> ConfigWriteResult {

--- a/Sources/FobApp/ContentView.swift
+++ b/Sources/FobApp/ContentView.swift
@@ -58,7 +58,6 @@ struct ContentView: View {
 
     @State private var openMenuKey: String?
     @State private var menuUsage: AppState.KeyUsage?
-    @State private var updateCopied = false
 
     private var t: Theme { Theme.current(scheme) }
     private let width: CGFloat = 360
@@ -133,12 +132,9 @@ struct ContentView: View {
             Spacer()
             Button("Notes") { if let u = state.updateAvailable { NSWorkspace.shared.open(u.url) } }
                 .buttonStyle(.plain).font(.system(size: 11, weight: .medium)).foregroundStyle(Theme.accent)
-            Button(updateCopied ? "Copied" : "Copy `brew upgrade`") {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString("brew upgrade --cask fob", forType: .string)
-                updateCopied = true
-            }
-            .buttonStyle(.plain).font(.system(size: 11, weight: .medium)).foregroundStyle(Theme.accent)
+            Button("Update") { state.updateViaHomebrew() }
+                .buttonStyle(.borderedProminent).controlSize(.small).font(.system(size: 11, weight: .semibold))
+                .help("Runs `brew upgrade --cask fob` in Terminal, then reopens fob")
         }
         .padding(.horizontal, 14).padding(.vertical, 10)
         .background(Theme.accent.opacity(0.08))


### PR DESCRIPTION
Fixes the friction reported after "Check now": the banner showed a new version but the only action was **Copy `brew upgrade`** — you still had to paste it into a terminal.

## What changed
The banner's action button is now **Update** (replacing Copy; **Notes** stays). It runs `AppState.updateViaHomebrew()`, which opens Terminal and executes the constant command:

```
brew upgrade --cask fob && open -a fob
```

## Why this shape (not Sparkle / not in-app replace)
fob is a **Homebrew cask**, so brew must stay the source of truth for the installed version. A Sparkle self-updater or an in-app download-and-replace would desync brew and (Sparkle) add a third-party dependency, breaking the zero-dep ethos. Triggering `brew upgrade` from the UI keeps brew authoritative, adds **zero dependencies**, is **transparent** (you see exactly what runs — a virtue for a security tool), and is robust: Terminal owns the process, so it survives the cask quitting/replacing fob mid-upgrade, and `&& open -a fob` relaunches only on success. Reuses the existing `openInTerminal` osascript pattern; the command is a constant, so no injection surface.

## Notes
- Non-Homebrew (source) installs just see brew's "not installed" message — harmless.
- This helps updates **after** it ships (the installed build must contain the button), so its first real payoff is the release following this one.

Build clean; 117 tests pass.