### PR TITLE
Document backup keys, losing a Mac, and key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,39 @@ It flags:
   *no* Touch ID prompt while they're loaded (fob's own keys are excluded).
 - **Opportunities** — plain-key hosts and non-fob signing keys you could move to fob.
 
+### 🔑 Backup keys, and losing a Mac
+
+A fob key is **device-bound**: it lives in that Mac's Secure Enclave and can't be exported,
+copied, or backed up. That's the whole security property — but it also means a fob key is
+**not recoverable** if the Mac is lost, wiped, or dies.
+
+That's a *lockout* risk, not a *compromise* risk: the on-disk blob is useless on any other
+machine and every use needs your presence, so a stolen Mac doesn't hand anyone your keys.
+
+Plan for it the way you would with a hardware token — keep a **second key registered** on
+anything you'd hate to be locked out of:
+
+- another Mac running fob,
+- a passphrase-protected key kept somewhere safe (password manager, offline storage), or
+- a hardware security key (`ssh-keygen -t ed25519-sk`).
+
+Servers take multiple entries in `~/.ssh/authorized_keys`, and GitHub/GitLab take multiple keys
+per account. Add the backup once and losing a Mac is an inconvenience, not a lockout.
+
+**If you do lose a Mac**, remove its public key from every host and account that trusted it
+(`~/.ssh/authorized_keys`, your git host's SSH-keys page). Nobody else can use that key, but
+pruning it keeps your authorized lists honest.
+
+**Replacing a key on purpose** — rotate without downtime:
+
+```sh
+fob rotate <key>              # mint a replacement alongside the current key
+fob rotate <key> --finalize   # swap it in and retire the old one
+```
+
+The key keeps its name, so `~/.ssh/config` and your git config need no changes. Register the new
+public key on the host between the two steps (the app's **Rotate** page walks through it).
+
 ## Security model
 
 fob is a **presence-gated key store, not a sandbox around your own logged-in session.**
@@ -288,6 +321,7 @@ Two independent audits of this codebase (findings resolved) plus a regression te
 | `fob generate <name> [--require-biometry]` | Create a Secure Enclave key |
 | `fob list` | Print public keys (authorized_keys format) |
 | `fob delete <key> [--force]` | Permanently erase a key from the enclave |
+| `fob rotate <key>` · `fob rotate <key> --finalize` | Replace a key with a fresh one, keeping its name |
 | `fob pin <key> <host>` · `fob unpin <key>` | Restrict a key to a host / remove all pins |
 | `fob reuse <key> <seconds\|off>` | Set the touch-reuse window (max 300 s) |
 | `fob policy` | Show every key's pin + reuse state |

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -34,6 +34,12 @@ USAGE:
       Permanently erase a key from the Secure Enclave (asks to confirm; --force
       skips). Remove its public key from any server/host that still trusts it.
 
+  fob rotate <name> [--require-biometry]   then   fob rotate <name> --finalize
+      Replace a key with a fresh Secure Enclave key, keeping the same name so
+      ~/.ssh/config and your git config need no changes. The first step mints the
+      replacement alongside the current key (register its public key on the host);
+      --finalize swaps it in and retires the old one. No downtime, no lockout.
+
   fob checkup
       Read-only SSH hygiene report: flags unencrypted / weak / loosely-permissioned
       on-disk keys, risky ~/.ssh/config directives, and hosts/signing that could move


### PR DESCRIPTION
Closes the most predictable objection to enclave-bound keys — *"the key can't be backed up, so what happens if my Mac dies?"* — which the README had no answer to. It's the first thing asked in every channel, so it should be link-able rather than improvised.

## New section: "Backup keys, and losing a Mac"

- Frames it accurately: device-bound keys are a **lockout risk, not a compromise risk** (the on-disk blob is useless on another machine, and every use needs presence — a stolen Mac hands over nothing).
- The mitigation, same as any hardware token: keep a **second key registered** on anything you'd hate to be locked out of — another Mac running fob, a passphrase-protected key in safe storage, or a `ssh-keygen -t ed25519-sk` hardware key. Servers and git hosts both accept multiple keys.
- What to do if a Mac *is* lost: prune its public key from the hosts and accounts that trusted it.
- How to replace a key on purpose, with no downtime.

## Bonus fix: `fob rotate` was undiscoverable

It existed but appeared in **neither** the CLI's `usage` output **nor** the README — so unless you read the source, you couldn't find it. Now documented in both.

Build clean, 117 tests pass. Docs + help text only; no behavior change.
